### PR TITLE
providers/studio: Add default chunkSize if upload is a stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "simple-git-hooks": "^2.8.0",
     "typechain": "^8.1.0",
     "typescript": "^4.8.2",
+    "vite": "^3.1.1",
     "vitest": "^0.23.1"
   },
   "simple-git-hooks": {

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -137,6 +137,9 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
           id: assetId,
         },
         uploadSize: args.uploadSize,
+        // Chunk size is required if input is a stream (and S3 min is 5MB), but
+        // not recommended if it is a file.
+        chunkSize: args.file instanceof File ? undefined : 5 * 1024 * 1024,
 
         onError(error) {
           reject(error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ importers:
       simple-git-hooks: ^2.8.0
       typechain: ^8.1.0
       typescript: ^4.8.2
+      vite: ^3.1.1
       vitest: ^0.23.1
     devDependencies:
       '@babel/core': 7.19.0
@@ -72,6 +73,7 @@ importers:
       simple-git-hooks: 2.8.0
       typechain: 8.1.0_typescript@4.8.2
       typescript: 4.8.2
+      vite: 3.1.1
       vitest: 0.23.1_dy3eolvvquedhjwqma34rzkxmm
 
   docs:
@@ -11323,8 +11325,8 @@ packages:
       unist-util-stringify-position: 3.0.2
       vfile-message: 3.1.2
 
-  /vite/3.1.0:
-    resolution: {integrity: sha512-YBg3dUicDpDWFCGttmvMbVyS9ydjntwEjwXRj2KBFwSB8SxmGcudo1yb8FW5+M/G86aS8x828ujnzUVdsLjs9g==}
+  /vite/3.1.1:
+    resolution: {integrity: sha512-hgxQWev/AL7nWYrqByYo8nfcH9n97v6oFsta9+JX8h6cEkni7nHKP2kJleNYV2kcGhE8jsbaY1aStwPZXzPbgA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -11384,7 +11386,7 @@ packages:
       tinybench: 2.1.5
       tinypool: 0.2.4
       tinyspy: 1.0.2
-      vite: 3.1.0
+      vite: 3.1.1
     transitivePeerDependencies:
       - less
       - sass


### PR DESCRIPTION
## Description

As per `tus-js-client` docs, the `chunkSize` is required when the input file is a stream: https://github.com/tus/tus-js-client/blob/14c3634e0ccd45973e90a3e460ca5e749f630107/docs/api.md#chunksize

The minimum chunk size for S3 (and Google) is 5MB as well, so let's use that: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html

## Additional Information

- [x] I read the [contributing docs](/livepeer/livepeer.js/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
