### PR TITLE
fix: add metrics duration

### DIFF
--- a/.changeset/brave-tigers-fix.md
+++ b/.changeset/brave-tigers-fix.md
@@ -1,0 +1,5 @@
+---
+'livepeer': patch
+---
+
+**Fix:** added media element duration to the metrics reporting plugin.

--- a/packages/core/src/media/metrics/metrics.test.ts
+++ b/packages/core/src/media/metrics/metrics.test.ts
@@ -72,6 +72,7 @@ describe('reportMediaMetrics', () => {
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
         {
+          "duration": 777,
           "firstPlayback": 0,
           "nError": 0,
           "nStalled": 0,
@@ -109,6 +110,7 @@ describe('reportMediaMetrics', () => {
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
         {
+          "duration": 777,
           "firstPlayback": 2000,
           "nError": 0,
           "nStalled": 0,
@@ -141,6 +143,7 @@ describe('reportMediaMetrics', () => {
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
         {
+          "duration": 777,
           "firstPlayback": 0,
           "nError": 0,
           "nStalled": 0,
@@ -175,6 +178,7 @@ describe('reportMediaMetrics', () => {
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
         {
+          "duration": 777,
           "firstPlayback": 0,
           "nError": 0,
           "nStalled": 1,

--- a/packages/core/src/media/metrics/metrics.ts
+++ b/packages/core/src/media/metrics/metrics.ts
@@ -23,6 +23,7 @@ export type RawMetrics = {
 
   pageUrl: string;
   sourceUrl: string;
+  duration: number | null;
 };
 
 export type PlaybackRecord = {
@@ -161,6 +162,7 @@ export class MetricsStatus<
       pageUrl: '',
       sourceUrl: '',
       playbackScore: null,
+      duration: null,
     };
 
     element.addEventListener('waiting', () => {
@@ -241,6 +243,7 @@ export class MetricsStatus<
       videoHeight: (this.element as HTMLVideoElement)?.videoHeight
         ? (this.element as HTMLVideoElement)?.videoHeight
         : null,
+      duration: this.element.duration,
 
       timeWaiting: this._getTimeWaiting(),
       timeStalled: this._getTimeStalled(),

--- a/packages/core/test/mocks.ts
+++ b/packages/core/test/mocks.ts
@@ -65,6 +65,10 @@ export class MockedVideoElement extends HTMLVideoElement {
   setAttribute = vi.fn(() => {
     return true;
   });
+
+  get duration() {
+    return 777;
+  }
 }
 
 // register the custom element


### PR DESCRIPTION
## Description

Added media element duration to the metrics reporting plugin.