### PR TITLE
Add object fit to Player

### DIFF
--- a/.changeset/five-dolphins-check.md
+++ b/.changeset/five-dolphins-check.md
@@ -1,0 +1,5 @@
+---
+'@livepeer/react': patch
+---
+
+**Fix:** added `objectFit` to `<Player />` to apply to the video/poster element, to either be `contain` or `cover` depending on the use-case.

--- a/docs/pages/react/Player.en-US.mdx
+++ b/docs/pages/react/Player.en-US.mdx
@@ -393,7 +393,7 @@ function App() {
 ### objectFit
 
 Sets the video's [object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) property. Defaults to `cover` -
-`contain` is usually used in full-screen applications or when the `aspectRatio` does not match the content (or there is not
+`contain` is usually used in full-screen applications or when the `aspectRatio` does not match the content (or there is no
 guarantee the `aspectRatio` matches).
 
 ```tsx {9}

--- a/docs/pages/react/Player.en-US.mdx
+++ b/docs/pages/react/Player.en-US.mdx
@@ -390,6 +390,34 @@ function App() {
   autoPlay
 />
 
+### objectFit
+
+Sets the video's [object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) property. Defaults to `cover` -
+`contain` is usually used in full-screen applications or when the `aspectRatio` does not match the content (or there is not
+guarantee the `aspectRatio` matches).
+
+```tsx {9}
+import { Player } from '@livepeer/react';
+
+function App() {
+  return (
+    <Player
+      title="Agent 327: Operation Barbershop"
+      playbackId="6d7el73r1y12chxr"
+      aspectRatio="1to1"
+      objectFit="contain"
+    />
+  );
+}
+```
+
+<Player
+  title="Agent 327: Operation Barbershop"
+  playbackId="6d7el73r1y12chxr"
+  aspectRatio="1to1"
+  objectFit="contain"
+/>
+
 ### theme
 
 Sets the Player-specific theme overrides. It is recommended to use [`LivepeerConfig`](/react/LivepeerConfig) for

--- a/examples/next/src/pages/player.tsx
+++ b/examples/next/src/pages/player.tsx
@@ -35,6 +35,7 @@ const PlayerPage: NextPage = () => {
     >
       <Player
         src={url}
+        objectFit="contain"
         playbackId={v ?? 'ce4d4q4z1hj08e2s'}
         muted={isTrue(muted)}
         autoPlay={isTrue(autoplay)}

--- a/packages/core/src/media/styling/media.ts
+++ b/packages/core/src/media/styling/media.ts
@@ -42,13 +42,16 @@ const video = css('video', {
           display: 'none !important',
         },
       },
-      default: {
+      contain: {
+        objectFit: 'contain',
+      },
+      cover: {
         objectFit: 'cover',
       },
     },
   },
   defaultVariants: {
-    size: 'default',
+    size: 'cover',
   },
 });
 

--- a/packages/react/src/components/media/AudioPlayer.tsx
+++ b/packages/react/src/components/media/AudioPlayer.tsx
@@ -23,7 +23,7 @@ const mediaControllerSelector = ({
 });
 
 export const AudioPlayer = React.forwardRef<HTMLAudioElement, AudioPlayerProps>(
-  ({ src, autoPlay, title, loop, muted }, ref) => {
+  ({ src, autoPlay, title, loop, muted, objectFit }, ref) => {
     const { fullscreen } = useMediaController(mediaControllerSelector);
 
     const filteredSources = React.useMemo(() => {
@@ -33,7 +33,7 @@ export const AudioPlayer = React.forwardRef<HTMLAudioElement, AudioPlayerProps>(
     return (
       <audio
         className={styling.media.audio({
-          size: fullscreen ? 'fullscreen' : 'default',
+          size: fullscreen ? 'fullscreen' : objectFit,
         })}
         loop={loop}
         aria-label={title ?? 'Audio player'}

--- a/packages/react/src/components/media/HlsPlayer.tsx
+++ b/packages/react/src/components/media/HlsPlayer.tsx
@@ -9,11 +9,13 @@ import {
 } from 'livepeer';
 import * as React from 'react';
 
+import { PlayerObjectFit } from './Player';
 import { VideoPlayer } from './VideoPlayer';
 import { useMediaController } from './context';
 
 export type HlsPlayerProps = {
   src: HlsSrc;
+  objectFit: PlayerObjectFit;
   hlsConfig?: HlsVideoConfig;
   controls?: boolean;
   width?: string | number;
@@ -40,7 +42,8 @@ const mediaControllerSelector = ({
 
 export const HlsPlayer = React.forwardRef<HTMLVideoElement, HlsPlayerProps>(
   (props, ref) => {
-    const { hlsConfig, src, autoPlay, title, loop, muted, poster } = props;
+    const { hlsConfig, src, autoPlay, title, loop, muted, poster, objectFit } =
+      props;
 
     const { element, fullscreen, setLive, onDurationChange, onCanPlay } =
       useMediaController(mediaControllerSelector);
@@ -88,7 +91,7 @@ export const HlsPlayer = React.forwardRef<HTMLVideoElement, HlsPlayerProps>(
     return !canPlayAppleMpeg && canUseHlsjs ? (
       <video
         className={styling.media.video({
-          size: fullscreen ? 'fullscreen' : 'default',
+          size: fullscreen ? 'fullscreen' : objectFit,
         })}
         loop={loop}
         aria-label={title ?? 'Video player'}

--- a/packages/react/src/components/media/Player.tsx
+++ b/packages/react/src/components/media/Player.tsx
@@ -27,6 +27,8 @@ import {
 } from './controls';
 import { Title } from './controls/Title';
 
+export type PlayerObjectFit = 'cover' | 'contain';
+
 export type PlayerProps = {
   /** The source(s) of the media (**required** if `playbackId` is not provided) */
   src?: string | string[] | null | undefined;
@@ -38,7 +40,7 @@ export type PlayerProps = {
   /** Shows/hides the title at the top of the media */
   showTitle?: boolean;
 
-  /** Whether the media will loop when finished */
+  /** Whether the media will loop when finished. Defaults to false. */
   loop?: boolean;
 
   /**
@@ -48,21 +50,29 @@ export type PlayerProps = {
    * @see {@link https://web.dev/cls/}
    * */
   aspectRatio?: AspectRatio;
-  /** Poster image to show when the content is either loading (when autoplaying) or hasn't started yet (without autoplay).
-   * It is highly recommended to also pass in a `title` attribute as well, for ARIA compatibility. */
+  /**
+   * Poster image to show when the content is either loading (when autoplaying) or hasn't started yet (without autoplay).
+   * It is highly recommended to also pass in a `title` attribute as well, for ARIA compatibility.
+   */
   poster?: string | React.ReactNode;
   /** Shows/hides the loading spinner */
   showLoadingSpinner?: boolean;
 
   /** Configuration for the event listeners */
   controls?: ControlsOptions;
-  /** Play media automatically when the content loads (if this is specified, you must also specify muted, since this is required in browsers) */
+  /**
+   * Play media automatically when the content loads (if this is specified, you must also specify muted,
+   * since this is required in browsers)
+   */
   autoPlay?: boolean;
   /** Mute media by default */
   muted?: boolean;
 
   /** Theme configuration for the player */
   theme?: ThemeConfig;
+
+  /** The object-fit property for the video element. Defaults to cover (contain is usually used in full-screen applications) */
+  objectFit?: PlayerObjectFit;
 
   /** Custom controls passed in to override the default controls */
   children?: React.ReactNode;
@@ -91,6 +101,7 @@ export function Player({
   showLoadingSpinner = true,
   showTitle = true,
   aspectRatio = '16to9',
+  objectFit = 'cover',
 }: PlayerProps) {
   const [mediaElement, setMediaElement] =
     React.useState<HTMLMediaElement | null>(null);
@@ -177,6 +188,7 @@ export function Player({
             src={sourceMimeTyped}
             poster={typeof poster === 'string' ? poster : undefined}
             loop={loop}
+            objectFit={objectFit}
           />
         ) : sourceMimeTyped?.[0]?.type === 'audio' ? (
           <AudioPlayer
@@ -185,6 +197,7 @@ export function Player({
             muted={autoPlay ? true : muted}
             src={sourceMimeTyped as AudioSrc[]}
             loop={loop}
+            objectFit={objectFit}
           />
         ) : (
           <VideoPlayer
@@ -194,6 +207,7 @@ export function Player({
             src={sourceMimeTyped as VideoSrc[] | null}
             poster={typeof poster === 'string' ? poster : undefined}
             loop={loop}
+            objectFit={objectFit}
           />
         )}
 

--- a/packages/react/src/components/media/VideoPlayer.tsx
+++ b/packages/react/src/components/media/VideoPlayer.tsx
@@ -20,7 +20,7 @@ const mediaControllerSelector = ({
 });
 
 export const VideoPlayer = React.forwardRef<HTMLVideoElement, VideoPlayerProps>(
-  ({ src, autoPlay, title, loop, muted, poster }, ref) => {
+  ({ src, autoPlay, title, loop, muted, poster, objectFit }, ref) => {
     const { fullscreen } = useMediaController(mediaControllerSelector);
 
     const filteredSources = React.useMemo(() => {
@@ -30,7 +30,7 @@ export const VideoPlayer = React.forwardRef<HTMLVideoElement, VideoPlayerProps>(
     return (
       <video
         className={styling.media.video({
-          size: fullscreen ? 'fullscreen' : 'default',
+          size: fullscreen ? 'fullscreen' : objectFit,
         })}
         loop={loop}
         aria-label={title ?? 'Video player'}


### PR DESCRIPTION
## Description

Added `objectFit` to `<Player />` to apply to the video/poster element, to either be `contain` or `cover` depending on the use-case.
