### PR TITLE
fix: remove meta field

### DIFF
--- a/.changeset/honest-hats-wash.md
+++ b/.changeset/honest-hats-wash.md
@@ -1,0 +1,6 @@
+---
+'livepeer': minor
+'@livepeer/react': minor
+---
+
+**Breaking:** removed the `meta` field on an Asset (which is a custom field stored in the Studio provider and not replicated to IPFS) to reduce confusion around metadata fields.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "preconstruct dev",
     "dev:docs": "pnpm dev && pnpm --filter docs dev",
     "example:next": "pnpm build && pnpm --filter example-next dev",
-    "generate-types": "yarn typechain --out-dir \"packages/core/src/contracts/types/typechain\" --target ethers-v5 \"packages/core/src/contracts/abis/**/**.json\"",
+    "generate-types": "pnpm typechain --out-dir \"packages/core/src/contracts/types/typechain\" --target ethers-v5 \"packages/core/src/contracts/abis/**/**.json\"",
     "lint": "eslint . --cache",
     "lint:fix": "pnpm lint --fix",
     "lint:format": "prettier --write",

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -127,7 +127,6 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
     >('/asset/request-upload', {
       json: {
         name: args.name,
-        meta: args.meta,
       },
       headers: this._defaultHeaders,
     });

--- a/packages/core/src/providers/studio/types.ts
+++ b/packages/core/src/providers/studio/types.ts
@@ -57,12 +57,7 @@ export type StudioAssetPatchPayload = {
    * Name of the asset. This is not necessarily the filename, can be a custom name or title
    */
   name?: string;
-  /**
-   * User input metadata associated with the asset
-   */
-  meta?: {
-    [k: string]: string;
-  };
+  /** Storage configs for the asset */
   storage?: {
     ipfs?:
       | {

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -151,8 +151,6 @@ export type AssetIdOrString =
 export type CreateAssetArgs = {
   /** Name for the new asset */
   name: string;
-  /** Metadata associated with the asset */
-  meta?: Record<string, string>;
   /** Content to be uploaded */
   file: File | ReadStream;
   /** Size of the upload file. Must provide this if the file is a ReadStream */
@@ -353,10 +351,7 @@ export type Asset = {
    * name or title
    */
   name: string;
-  /** User-managed metadata associated with the asset */
-  meta?: {
-    [k: string]: string;
-  };
+  /** Storage configs for the asset */
   storage?: {
     ipfs?: {
       /** CID of the file on IPFS */


### PR DESCRIPTION
## Description

**Breaking:** removed the `meta` field on an Asset (which is a custom field stored in the Studio provider and not replicated to IPFS) to reduce confusion around metadata fields.
