### PR TITLE
[WIP] feat: added automatic fetching/importing of IPFS CID/URLs

### DIFF
--- a/.changeset/funny-hounds-vanish.md
+++ b/.changeset/funny-hounds-vanish.md
@@ -1,0 +1,8 @@
+---
+'livepeer': patch
+'@livepeer/react': patch
+---
+
+**Feature:** Added automatic fetching/importing of IPFS URLs to the Player.
+
+An IPFS [v0 or v1 CID](https://docs.ipfs.tech/concepts/content-addressing/) or URL (such as `ipfs://<CID>`, `https://<CID>.ipfs.dweb.link/` or `https://cloudflare-ipfs.com/ipfs/<CID>`, _but cannot be a directory_) can be passed as the `src` or `playbackID` to the Player, and it will automatically detect if it is a valid CID and attempt to fetch the playback info for the CID. If the API does not have an Asset with the corresponding CID, the Player will automatically attempt to import the CID from IPFS, and then play the transcoded content back.

--- a/docs/components/core/Providers.tsx
+++ b/docs/components/core/Providers.tsx
@@ -30,7 +30,7 @@ const livepeerClient = createReactClient({
   provider: studioProvider({
     apiKey: process.env.NEXT_PUBLIC_STUDIO_API_KEY,
     baseUrl:
-      process.env.VERCEL_ENV === 'preview'
+      process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
         ? 'https://livepeer.monster/api'
         : defaultStudioConfig.baseUrl,
   }),

--- a/docs/components/core/Providers.tsx
+++ b/docs/components/core/Providers.tsx
@@ -28,6 +28,8 @@ const wagmiClient = createClient(
 const livepeerClient = createReactClient({
   provider: studioProvider({
     apiKey: process.env.NEXT_PUBLIC_STUDIO_API_KEY,
+    // TODO REMOVE THIS
+    baseUrl: 'https://livepeer.monster/api',
   }),
 });
 

--- a/docs/components/core/Providers.tsx
+++ b/docs/components/core/Providers.tsx
@@ -2,6 +2,7 @@ import {
   LivepeerConfig,
   ThemeConfig,
   createReactClient,
+  defaultStudioConfig,
   studioProvider,
 } from '@livepeer/react';
 import { AptosClient } from 'aptos';
@@ -28,8 +29,10 @@ const wagmiClient = createClient(
 const livepeerClient = createReactClient({
   provider: studioProvider({
     apiKey: process.env.NEXT_PUBLIC_STUDIO_API_KEY,
-    // TODO REMOVE THIS
-    baseUrl: 'https://livepeer.monster/api',
+    baseUrl:
+      process.env.VERCEL_ENV === 'production'
+        ? defaultStudioConfig.baseUrl
+        : 'https://livepeer.monster/api',
   }),
 });
 

--- a/docs/components/core/Providers.tsx
+++ b/docs/components/core/Providers.tsx
@@ -30,9 +30,9 @@ const livepeerClient = createReactClient({
   provider: studioProvider({
     apiKey: process.env.NEXT_PUBLIC_STUDIO_API_KEY,
     baseUrl:
-      process.env.VERCEL_ENV === 'production'
-        ? defaultStudioConfig.baseUrl
-        : 'https://livepeer.monster/api',
+      process.env.VERCEL_ENV === 'preview'
+        ? 'https://livepeer.monster/api'
+        : defaultStudioConfig.baseUrl,
   }),
 });
 

--- a/docs/components/examples/IpfsPlayback.tsx
+++ b/docs/components/examples/IpfsPlayback.tsx
@@ -1,0 +1,44 @@
+import { Box, Text, TextField } from '@livepeer/design-system';
+import { Player } from '@livepeer/react';
+import { parseCid } from 'livepeer/media';
+
+import { useMemo, useState } from 'react';
+
+export const IpfsPlayback = () => {
+  const [ipfsUrl, setIpfsUrl] = useState<string>('');
+
+  const ipfsParsed = useMemo(() => parseCid(ipfsUrl), [ipfsUrl]);
+
+  return (
+    <Box css={{ my: '$6' }}>
+      <Box
+        css={{
+          mb: '$3',
+          width: '100%',
+        }}
+      >
+        <Text css={{ my: '$1' }} variant="gray">
+          IPFS URL
+        </Text>
+        <TextField
+          size="3"
+          type="text"
+          placeholder="https://cloudflare-ipfs.com/ipfs/..."
+          onChange={(e) => setIpfsUrl(e.target.value)}
+        />
+
+        {ipfsUrl && !ipfsParsed && (
+          <Text css={{ my: '$1' }} variant="red">
+            Provided value is not a valid CID.
+          </Text>
+        )}
+      </Box>
+
+      {ipfsParsed && (
+        <Box css={{ mt: '$2' }}>
+          <Player title={ipfsParsed.cid} src={ipfsUrl} autoPlay muted />
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/docs/components/examples/Stream.tsx
+++ b/docs/components/examples/Stream.tsx
@@ -71,11 +71,6 @@ export const Stream = () => {
             playbackId={stream?.playbackId}
             autoPlay
             muted
-            theme={{
-              fonts: {
-                display: 'Inter',
-              },
-            }}
           />
         </Box>
       )}

--- a/docs/components/examples/index.ts
+++ b/docs/components/examples/index.ts
@@ -1,5 +1,6 @@
 export * from './AptosNft';
 export * from './Asset';
 export * from './DemoPlayer';
+export * from './IpfsPlayback';
 export * from './Stream';
 export * from './WagmiNft';

--- a/docs/pages/examples/react/ipfs-playback.en-US.mdx
+++ b/docs/pages/examples/react/ipfs-playback.en-US.mdx
@@ -8,8 +8,8 @@ import { IpfsPlayback } from '@components/examples';
 
 # Play a Video from IPFS
 
-Playing back video from IPFS is easy with livepeer.js! The example below uses [`useCreateAsset`](/react/hooks/useCreateAsset)
-and [`useAsset`](/react/hooks/useAsset) to create and view a video asset.
+Playing back video from IPFS is easy with livepeer.js! The example below uses the Player's built-in automatic IPFS import to
+play back transcoded IPFS content without any additional configuration.
 
 <IpfsPlayback />
 
@@ -47,188 +47,44 @@ function App() {
 }
 ```
 
-## Step 2: Video File Upload
+## Step 2: IPFS Playback
 
-Now that our providers are set up, we set up file uploads with [React Dropzone](https://react-dropzone.js.org/),
-a library for easily creating HTML5-compliant drag and drop zones for files (you can use another solution for file uploads):
+Now that our providers are set up, we can add a text input for an IPFS CID or URL using `parseCid` from the core `livepeer` package - _this is only
+used for UI purposes, to provide feedback if the user input is valid_.
 
-```tsx
-import { useCreateAsset } from '@livepeer/react';
-
-import { useCallback, useState } from 'react';
-import { useDropzone } from 'react-dropzone';
-
-export const CreateAndViewAsset = () => {
-  const [video, setVideo] = useState<File | undefined>();
-  const {
-    mutate: createAsset,
-    data: createdAsset,
-    status: createStatus,
-    error: createError,
-    uploadProgress,
-  } = useCreateAsset();
-
-  const onDrop = useCallback(async (acceptedFiles: File[]) => {
-    if (acceptedFiles && acceptedFiles.length > 0 && acceptedFiles?.[0]) {
-      setVideo(acceptedFiles[0]);
-    }
-  }, []);
-
-  const { getRootProps, getInputProps } = useDropzone({
-    accept: {
-      'video/*': ['*.mp4'],
-    },
-    maxFiles: 1,
-    onDrop,
-  });
-
-  const progressFormatted = useMemo(
-    () =>
-      uploadProgress
-        ? `Uploading: ${Math.round(uploadProgress * 100)}%`
-        : asset?.status?.progress
-        ? `Processing: ${Math.round(asset?.status?.progress * 100)}%`
-        : null,
-    [uploadProgress, asset?.status?.progress],
-  );
-
-  return (
-    <>
-      <Box {...getRootProps()}>
-        <Box as="input" {...getInputProps()} />
-        <Box as="p">
-          <Text>Drag and drop or browse files</Text>
-        </Box>
-      </Box>
-
-      {createError?.message && <Text>{createError.message}</Text>}
-
-      {video ? (
-        <Badge>{video.name}</Badge>
-      ) : (
-        <Text>Select a video file to upload.</Text>
-      )}
-      {progressFormatted && <Text>{progressFormatted}</Text>}
-
-      <Button
-        onClick={() => {
-          if (video) {
-            createAsset({ name: video.name, file: video });
-          }
-        }}
-        disabled={!video || createStatus === 'loading'}
-      >
-        Upload
-      </Button>
-    </>
-  );
-};
-```
-
-## Step 3: Stream Transcoded Video
-
-Lastly, when the video is uploaded, we use `refetchInterval` to poll the API until the asset has been processed and
-has a `playbackId`. Then, we stop polling and show the video using the [`Player`](/react/Player).
+If the input is valid, we then pass that input to the [`Player`](/react/Player), which automatically detects if it is a valid CID and attempts
+to fetch the playback info for that CID. If the provider does not have an `Asset` with that CID, the Player will automatically attempt
+to import the CID from IPFS, and then play the transcoded content back, without any additional code on the frontend.
 
 ```tsx
-import { Player, useAsset, useCreateAsset } from '@livepeer/react';
+import { Player } from '@livepeer/react';
+import { parseCid } from 'livepeer/media';
 
-import { useCallback, useMemo, useState } from 'react';
-import { useDropzone } from 'react-dropzone';
+import { useMemo, useState } from 'react';
 
-export const CreateAndViewAsset = () => {
-  const [video, setVideo] = useState<File | undefined>();
-  const {
-    mutate: createAsset,
-    data: createdAsset,
-    status: createStatus,
-    error: createError,
-    uploadProgress,
-  } = useCreateAsset();
-  const { data: asset, status: assetStatus } = useAsset({
-    assetId: createdAsset?.id,
-    refetchInterval: (asset) =>
-      asset?.status?.phase !== 'ready' ? 5000 : false,
-  });
-  const { data: metrics } = useAssetMetrics({
-    assetId: createdAsset?.id,
-    refetchInterval: 30000,
-  });
+export const IpfsPlayback = () => {
+  const [ipfsUrl, setIpfsUrl] = useState<string>('');
 
-  const onDrop = useCallback(async (acceptedFiles: File[]) => {
-    if (acceptedFiles && acceptedFiles.length > 0 && acceptedFiles?.[0]) {
-      setVideo(acceptedFiles[0]);
-    }
-  }, []);
-
-  const { getRootProps, getInputProps } = useDropzone({
-    accept: {
-      'video/*': ['*.mp4'],
-    },
-    maxFiles: 1,
-    onDrop,
-  });
-
-  // we check here for either creating the asset, or polling for the asset
-  // until the video is in the ready phase and can be consumed
-  const isLoading = useMemo(
-    () =>
-      createStatus === 'loading' ||
-      assetStatus === 'loading' ||
-      (asset && asset?.status?.phase !== 'ready'),
-    [createStatus, asset, assetStatus],
-  );
-
-  const progressFormatted = useMemo(
-    () =>
-      uploadProgress
-        ? `Uploading: ${Math.round(uploadProgress * 100)}%`
-        : asset?.status?.progress
-        ? `Processing: ${Math.round(asset?.status?.progress * 100)}%`
-        : null,
-    [uploadProgress, asset?.status?.progress],
-  );
+  const ipfsParsed = useMemo(() => parseCid(ipfsUrl), [ipfsUrl]);
 
   return (
-    <>
-      <Box {...getRootProps()}>
-        <Box as="input" {...getInputProps()} />
-        <Box as="p">
-          <Text>Drag and drop or browse files</Text>
-        </Box>
+    <Box>
+      <Box>
+        <TextField onChange={(e) => setIpfsUrl(e.target.value)} />
+
+        {ipfsUrl && !ipfsParsed && (
+          <Text>Provided value is not a valid CID.</Text>
+        )}
       </Box>
 
-      {createError?.message && <Text>{createError.message}</Text>}
-
-      {video ? (
-        <Badge>{video.name}</Badge>
-      ) : (
-        <Text>Select a video file to upload.</Text>
+      {ipfsParsed && (
+        <Player title={ipfsParsed.cid} src={ipfsUrl} autoPlay muted />
       )}
-      {progressFormatted && <Text>{progressFormatted}</Text>}
-
-      <Button
-        onClick={() => {
-          if (video) {
-            createAsset({ name: video.name, file: video });
-          }
-        }}
-        disabled={!video || isLoading || Boolean(asset)}
-      >
-        {isLoading && <Spinner />}
-        Upload
-      </Button>
-
-      {asset?.playbackId && <Player playbackId={asset?.playbackId} />}
-
-      {metrics?.metrics?.[0] && (
-        <Badge>Views: {metrics?.metrics?.[0]?.startViews}</Badge>
-      )}
-    </>
+    </Box>
   );
 };
 ```
 
 ## Wrap Up
 
-That's it! You just set up a scalable, decentralized video asset streaming solution for an app.
+That's it! You just configured a caching & transcoding layer on top of IPFS with a few lines of code!

--- a/docs/pages/examples/react/ipfs-playback.en-US.mdx
+++ b/docs/pages/examples/react/ipfs-playback.en-US.mdx
@@ -1,0 +1,234 @@
+---
+title: 'Play a Video from IPFS'
+description: 'Learn how to import and play back a video on IPFS with livepeer.js'
+---
+
+import { Callout } from 'nextra-theme-docs';
+import { IpfsPlayback } from '@components/examples';
+
+# Play a Video from IPFS
+
+Playing back video from IPFS is easy with livepeer.js! The example below uses [`useCreateAsset`](/react/hooks/useCreateAsset)
+and [`useAsset`](/react/hooks/useAsset) to create and view a video asset.
+
+<IpfsPlayback />
+
+## Step 1: Configuring Providers
+
+<Callout>
+  This example assumes you have chosen a component library with typical
+  components like `Button`, `TextField`, `Spinner`, etc. The
+  [`Player`](/react/Player) is the only visual component provided.
+</Callout>
+
+First, we create a new livepeer.js client with the Studio provider and a [CORS-protected API key](/react/providers/studio#apikey):
+
+```tsx
+import {
+  LivepeerConfig,
+  createReactClient,
+  studioProvider,
+} from '@livepeer/react';
+import * as React from 'react';
+
+const livepeerClient = createReactClient({
+  provider: studioProvider({
+    apiKey: process.env.NEXT_PUBLIC_STUDIO_API_KEY,
+  }),
+});
+
+// Pass client to React Context Provider
+function App() {
+  return (
+    <LivepeerConfig client={livepeerClient}>
+      <CreateAndViewAsset />
+    </LivepeerConfig>
+  );
+}
+```
+
+## Step 2: Video File Upload
+
+Now that our providers are set up, we set up file uploads with [React Dropzone](https://react-dropzone.js.org/),
+a library for easily creating HTML5-compliant drag and drop zones for files (you can use another solution for file uploads):
+
+```tsx
+import { useCreateAsset } from '@livepeer/react';
+
+import { useCallback, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+export const CreateAndViewAsset = () => {
+  const [video, setVideo] = useState<File | undefined>();
+  const {
+    mutate: createAsset,
+    data: createdAsset,
+    status: createStatus,
+    error: createError,
+    uploadProgress,
+  } = useCreateAsset();
+
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    if (acceptedFiles && acceptedFiles.length > 0 && acceptedFiles?.[0]) {
+      setVideo(acceptedFiles[0]);
+    }
+  }, []);
+
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: {
+      'video/*': ['*.mp4'],
+    },
+    maxFiles: 1,
+    onDrop,
+  });
+
+  const progressFormatted = useMemo(
+    () =>
+      uploadProgress
+        ? `Uploading: ${Math.round(uploadProgress * 100)}%`
+        : asset?.status?.progress
+        ? `Processing: ${Math.round(asset?.status?.progress * 100)}%`
+        : null,
+    [uploadProgress, asset?.status?.progress],
+  );
+
+  return (
+    <>
+      <Box {...getRootProps()}>
+        <Box as="input" {...getInputProps()} />
+        <Box as="p">
+          <Text>Drag and drop or browse files</Text>
+        </Box>
+      </Box>
+
+      {createError?.message && <Text>{createError.message}</Text>}
+
+      {video ? (
+        <Badge>{video.name}</Badge>
+      ) : (
+        <Text>Select a video file to upload.</Text>
+      )}
+      {progressFormatted && <Text>{progressFormatted}</Text>}
+
+      <Button
+        onClick={() => {
+          if (video) {
+            createAsset({ name: video.name, file: video });
+          }
+        }}
+        disabled={!video || createStatus === 'loading'}
+      >
+        Upload
+      </Button>
+    </>
+  );
+};
+```
+
+## Step 3: Stream Transcoded Video
+
+Lastly, when the video is uploaded, we use `refetchInterval` to poll the API until the asset has been processed and
+has a `playbackId`. Then, we stop polling and show the video using the [`Player`](/react/Player).
+
+```tsx
+import { Player, useAsset, useCreateAsset } from '@livepeer/react';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+export const CreateAndViewAsset = () => {
+  const [video, setVideo] = useState<File | undefined>();
+  const {
+    mutate: createAsset,
+    data: createdAsset,
+    status: createStatus,
+    error: createError,
+    uploadProgress,
+  } = useCreateAsset();
+  const { data: asset, status: assetStatus } = useAsset({
+    assetId: createdAsset?.id,
+    refetchInterval: (asset) =>
+      asset?.status?.phase !== 'ready' ? 5000 : false,
+  });
+  const { data: metrics } = useAssetMetrics({
+    assetId: createdAsset?.id,
+    refetchInterval: 30000,
+  });
+
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    if (acceptedFiles && acceptedFiles.length > 0 && acceptedFiles?.[0]) {
+      setVideo(acceptedFiles[0]);
+    }
+  }, []);
+
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: {
+      'video/*': ['*.mp4'],
+    },
+    maxFiles: 1,
+    onDrop,
+  });
+
+  // we check here for either creating the asset, or polling for the asset
+  // until the video is in the ready phase and can be consumed
+  const isLoading = useMemo(
+    () =>
+      createStatus === 'loading' ||
+      assetStatus === 'loading' ||
+      (asset && asset?.status?.phase !== 'ready'),
+    [createStatus, asset, assetStatus],
+  );
+
+  const progressFormatted = useMemo(
+    () =>
+      uploadProgress
+        ? `Uploading: ${Math.round(uploadProgress * 100)}%`
+        : asset?.status?.progress
+        ? `Processing: ${Math.round(asset?.status?.progress * 100)}%`
+        : null,
+    [uploadProgress, asset?.status?.progress],
+  );
+
+  return (
+    <>
+      <Box {...getRootProps()}>
+        <Box as="input" {...getInputProps()} />
+        <Box as="p">
+          <Text>Drag and drop or browse files</Text>
+        </Box>
+      </Box>
+
+      {createError?.message && <Text>{createError.message}</Text>}
+
+      {video ? (
+        <Badge>{video.name}</Badge>
+      ) : (
+        <Text>Select a video file to upload.</Text>
+      )}
+      {progressFormatted && <Text>{progressFormatted}</Text>}
+
+      <Button
+        onClick={() => {
+          if (video) {
+            createAsset({ name: video.name, file: video });
+          }
+        }}
+        disabled={!video || isLoading || Boolean(asset)}
+      >
+        {isLoading && <Spinner />}
+        Upload
+      </Button>
+
+      {asset?.playbackId && <Player playbackId={asset?.playbackId} />}
+
+      {metrics?.metrics?.[0] && (
+        <Badge>Views: {metrics?.metrics?.[0]?.startViews}</Badge>
+      )}
+    </>
+  );
+};
+```
+
+## Wrap Up
+
+That's it! You just set up a scalable, decentralized video asset streaming solution for an app.

--- a/docs/pages/examples/react/ipfs-playback.en-US.mdx
+++ b/docs/pages/examples/react/ipfs-playback.en-US.mdx
@@ -41,7 +41,7 @@ const livepeerClient = createReactClient({
 function App() {
   return (
     <LivepeerConfig client={livepeerClient}>
-      <CreateAndViewAsset />
+      <IpfsPlayback />
     </LivepeerConfig>
   );
 }

--- a/docs/pages/examples/react/meta.en-US.json
+++ b/docs/pages/examples/react/meta.en-US.json
@@ -1,6 +1,7 @@
 {
   "player": "Player",
-  "view-asset": "Create & Watch an Asset",
   "view-stream": "Create & Watch a Stream",
-  "video-nft": "Mint a Video NFT"
+  "view-asset": "Create & Watch an Asset",
+  "video-nft": "Mint a Video NFT from an Asset",
+  "ipfs-playback": "Play a Video from IPFS"
 }

--- a/docs/pages/react/Player.en-US.mdx
+++ b/docs/pages/react/Player.en-US.mdx
@@ -452,14 +452,16 @@ function App() {
   showPipButton
 />
 
-### autoImportIpfs
+### autoImport
 
-Enables the automatic import from IPFS. Defaults to `true`.
+Enables automatic import and playback from decentralized storage providers. Currently supports IPFS CIDs/URLs. Defaults to `true`.
 
-An IPFS [v0 or v1 CID](https://docs.ipfs.tech/concepts/content-addressing/) or URL (such as `ipfs://<CID>`, `https://<CID>.ipfs.dweb.link/` or
-`https://cloudflare-ipfs.com/ipfs/<CID>`, _but cannot be a directory_) can be passed as the `src` or `playbackID` to the Player, and it will
-automatically detect if it is a valid CID and attempt to fetch the playback info for the CID. If the API does not have an Asset with the corresponding CID,
-the Player will automatically attempt to import the CID from IPFS, and then play the transcoded content back.
+<Callout>
+  An IPFS [v0 or v1 CID](https://docs.ipfs.tech/concepts/content-addressing/) or URL (such as `ipfs://<CID>`, `https://<CID>.ipfs.dweb.link/` or
+  `https://cloudflare-ipfs.com/ipfs/<CID>`, _but not a directory_) can be passed as the `src` or `playbackID` to the Player, and it will
+  automatically detect if it is a valid CID and attempt to fetch the playback info for the CID. If the API does not have an Asset with the corresponding CID,
+  the Player will automatically attempt to import the CID from IPFS, and then play the transcoded content back.
+</Callout>
 
 ```tsx {8}
 import { Player } from '@livepeer/react';
@@ -469,7 +471,7 @@ function App() {
     <Player
       title="Agent 327: Operation Barbershop"
       playbackId="Qmc5rn4Hi8a5JJQdrVAKyeEpCNJnM8t5fhJnoobstVcSFB"
-      autoImportIpfs
+      autoImport
     />
   );
 }
@@ -478,7 +480,7 @@ function App() {
 <Player
   title="Agent 327: Operation Barbershop"
   playbackId="Qmc5rn4Hi8a5JJQdrVAKyeEpCNJnM8t5fhJnoobstVcSFB"
-  autoImportIpfs
+  autoImport
 />
 
 ### theme

--- a/docs/pages/react/Player.en-US.mdx
+++ b/docs/pages/react/Player.en-US.mdx
@@ -452,6 +452,35 @@ function App() {
   showPipButton
 />
 
+### autoImportIpfs
+
+Enables the automatic import from IPFS. Defaults to `true`.
+
+An IPFS [v0 or v1 CID](https://docs.ipfs.tech/concepts/content-addressing/) or URL (such as `ipfs://<CID>`, `https://<CID>.ipfs.dweb.link/` or
+`https://cloudflare-ipfs.com/ipfs/<CID>`, _but cannot be a directory_) can be passed as the `src` or `playbackID` to the Player, and it will
+automatically detect if it is a valid CID and attempt to fetch the playback info for the CID. If the API does not have an Asset with the corresponding CID,
+the Player will automatically attempt to import the CID from IPFS, and then play the transcoded content back.
+
+```tsx {8}
+import { Player } from '@livepeer/react';
+
+function App() {
+  return (
+    <Player
+      title="Agent 327: Operation Barbershop"
+      playbackId="Qmc5rn4Hi8a5JJQdrVAKyeEpCNJnM8t5fhJnoobstVcSFB"
+      autoImportIpfs
+    />
+  );
+}
+```
+
+<Player
+  title="Agent 327: Operation Barbershop"
+  playbackId="Qmc5rn4Hi8a5JJQdrVAKyeEpCNJnM8t5fhJnoobstVcSFB"
+  autoImportIpfs
+/>
+
 ### theme
 
 Sets the Player-specific theme overrides. It is recommended to use [`LivepeerConfig`](/react/LivepeerConfig) for

--- a/docs/pages/react/asset/useCreateAsset.en-US.mdx
+++ b/docs/pages/react/asset/useCreateAsset.en-US.mdx
@@ -99,13 +99,28 @@ The variables for the mutate function(s) are defined as:
 
 ```tsx
 type CreateAssetArgs = {
+  /** Name for the new asset */
   name: string;
-  file: File;
+
+  /** External URL to be imported */
+  url?: string;
+
+  /** Content to be uploaded */
+  file?: File | ReadStream;
+  /** Size of the upload file. Must provide this if the file is a ReadStream */
+  uploadSize?: number;
+
+  /**
+   * Callback to receive progress (0-1 completion ratio) updates of the upload.
+   */
+  onUploadProgress?: (progress: number) => void;
 };
 ```
 
-The `useCreateAsset` hook uses [tus](https://github.com/tus/tus-js-client) for resumable uploads and checks for existing uploads by default, before starting a
+If a file is provided, the `useCreateAsset` hook uses [tus](https://github.com/tus/tus-js-client) for resumable uploads and checks for existing uploads by default, before starting a
 new upload.
+
+If a URL is provided, the hook will make a request to the background to start an import. **Either a URL or file must be provided.**
 
 ## Configuration
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -115,6 +115,7 @@
     "core-js": "^3.25.5",
     "cross-fetch": "^3.1.5",
     "hls.js": "^1.2.4",
+    "multiformats": "^10.0.2",
     "tus-js-client": "^3.0.1",
     "zustand": "^4.1.1"
   },

--- a/packages/core/src/media/decentralizedStorage.test.ts
+++ b/packages/core/src/media/decentralizedStorage.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCid } from './decentralizedStorage';
+
+const ipfsPathGateways = [
+  'https://w3s.link/ipfs/',
+  'https://ipfs.io/ipfs/',
+  'https://cloudflare-ipfs.com/ipfs/',
+] as const;
+
+const ipfsSubdomainGateways = [
+  `https://replace.ipfs.dweb.link`,
+  `https://replace.ipfs.cf-ipfs.com`,
+  `https://replace.ipfs.localhost:8080`,
+] as const;
+
+describe('parseCid', () => {
+  it('handles an IPFS CID', async () => {
+    const sourceCid =
+      'bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy';
+
+    const url = parseCid(sourceCid);
+
+    expect(url?.url).toEqual(
+      'ipfs://bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy',
+    );
+  });
+
+  it('errors on paths in a CID', async () => {
+    const sourceCid =
+      'bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy/somepath.mp4';
+
+    const url = parseCid(sourceCid);
+
+    expect(url).toEqual(null);
+  });
+
+  it('errors on malformatted CID', async () => {
+    const sourceCid =
+      'UUfybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy';
+
+    const url = parseCid(sourceCid);
+
+    expect(url).toEqual(null);
+  });
+
+  it('handles a regular ipfs url', async () => {
+    const sourceUrl =
+      'ipfs://bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy';
+
+    const url = parseCid(sourceUrl);
+
+    expect(url?.url).toEqual(sourceUrl);
+  });
+
+  it('errors on paths in a regular ipfs url', async () => {
+    const sourceUrl =
+      'ipfs://bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy/somepath.mp4';
+
+    const url = parseCid(sourceUrl);
+
+    expect(url).toEqual(null);
+  });
+
+  it('errors on query params in a regular ipfs url', async () => {
+    const sourceUrl =
+      'ipfs://bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy?key=value';
+
+    const url = parseCid(sourceUrl);
+
+    expect(url).toEqual(null);
+  });
+
+  it('handles ipfs gateways', async () => {
+    for (const gateway of ipfsPathGateways) {
+      const url = parseCid(
+        `${gateway}bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy`,
+      );
+
+      expect(url?.url).toEqual(
+        'ipfs://bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy',
+      );
+    }
+  });
+
+  it('errors on malformatted CIDs in ipfs gateways', async () => {
+    for (const gateway of ipfsPathGateways) {
+      const url = parseCid(
+        `${gateway}bafybeiar26nqkdtiUUzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy`,
+      );
+
+      expect(url).toEqual(null);
+    }
+  });
+
+  it('errors on paths in an ipfs gateway', async () => {
+    for (const gateway of ipfsPathGateways) {
+      const url = parseCid(
+        `${gateway}bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy/somepath.mp4`,
+      );
+
+      expect(url).toEqual(null);
+    }
+  });
+
+  it('handles subdomain gateways', async () => {
+    for (const gateway of ipfsSubdomainGateways) {
+      const url = parseCid(
+        gateway.replace(
+          'replace',
+          'bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy',
+        ),
+      );
+
+      expect(url?.url).toEqual(
+        'ipfs://bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy',
+      );
+    }
+  });
+
+  it('errors on paths in a subdomain gateway', async () => {
+    for (const gateway of ipfsSubdomainGateways) {
+      const url = parseCid(
+        `${gateway.replace(
+          'replace',
+          'bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy',
+        )}/somepath.mp4`,
+      );
+
+      expect(url).toEqual(null);
+    }
+  });
+
+  it('errors on query params in a subdomain gateway', async () => {
+    for (const gateway of ipfsSubdomainGateways) {
+      const url = parseCid(
+        `${gateway.replace(
+          'replace',
+          'bafybeiar26nqkdtiyrzbaxwcdm7zkr2o36xljqskdvg6z6ugwlmpkdhamy',
+        )}?key=value`,
+      );
+
+      expect(url).toEqual(null);
+    }
+  });
+});

--- a/packages/core/src/media/decentralizedStorage.ts
+++ b/packages/core/src/media/decentralizedStorage.ts
@@ -11,7 +11,7 @@ const pathGatewayPattern = /^https?:\/\/[^/]+\/(ip[fn]s)\/([^/?#]+)$/;
 const subdomainGatewayPattern = /^https?:\/\/([^/]+)\.(ip[fn]s)\.[^/?#]+$/;
 
 /**
- * Takes an IPFS URL and returns a formatted IPFS URL if the URL is valid.
+ * Takes an IPFS CID or URL and returns a formatted IPFS URL if the CID/URL is valid.
  * _This does not allow paths, query params, or hash in the URL and will return null_.
  *
  * @param possibleIpfsString A possible URL for an IPFS resource. Can be a gateway or IPFS protocol URL.

--- a/packages/core/src/media/decentralizedStorage.ts
+++ b/packages/core/src/media/decentralizedStorage.ts
@@ -1,0 +1,81 @@
+import { CID } from 'multiformats/cid';
+
+// IPFS CID (naive check for URL indicators)
+const ipfsCidPattern = /^([^/?#]+)$/;
+
+// IPFS Protocol
+const ipfsProtocolPattern = /^(ip[fn]s):\/\/([^/?#]+)$/;
+
+// Gateways
+const pathGatewayPattern = /^https?:\/\/[^/]+\/(ip[fn]s)\/([^/?#]+)$/;
+const subdomainGatewayPattern = /^https?:\/\/([^/]+)\.(ip[fn]s)\.[^/?#]+$/;
+
+/**
+ * Takes an IPFS URL and returns a formatted IPFS URL if the URL is valid.
+ * _This does not allow paths, query params, or hash in the URL and will return null_.
+ *
+ * @param possibleIpfsString A possible URL for an IPFS resource. Can be a gateway or IPFS protocol URL.
+ * @returns The formatted IPFS URI with protocol and CID. Returns null if the URL is not valid.
+ */
+export const parseCid = (possibleIpfsString: string | null | undefined) => {
+  if (!possibleIpfsString) {
+    return null;
+  }
+
+  const ipfsProtocolCid = possibleIpfsString.match(ipfsProtocolPattern)?.[2];
+
+  if (isCid(ipfsProtocolCid)) {
+    return formatReturnCid(ipfsProtocolCid);
+  }
+
+  const subdomainGatewayCid = possibleIpfsString.match(
+    subdomainGatewayPattern,
+  )?.[1];
+
+  if (isCid(subdomainGatewayCid)) {
+    return formatReturnCid(subdomainGatewayCid);
+  }
+
+  const pathGatewayCid = possibleIpfsString.match(pathGatewayPattern)?.[2];
+
+  if (isCid(pathGatewayCid)) {
+    return formatReturnCid(pathGatewayCid);
+  }
+
+  const ipfsCid = possibleIpfsString.match(ipfsCidPattern)?.[1];
+
+  if (isCid(ipfsCid)) {
+    return formatReturnCid(ipfsCid);
+  }
+
+  return null;
+};
+
+export const isCid = (
+  hash: CID | Uint8Array | string | undefined | null,
+): hash is CID => {
+  try {
+    if (!hash) {
+      return false;
+    }
+
+    if (typeof hash === 'string') {
+      return Boolean(CID.parse(hash));
+    }
+
+    if (hash instanceof Uint8Array) {
+      return Boolean(CID.decode(hash));
+    }
+
+    return Boolean(CID.asCID(hash));
+  } catch {
+    return false;
+  }
+};
+
+const formatReturnCid = (cid: string) => {
+  return {
+    url: `ipfs://${cid}`,
+    cid,
+  };
+};

--- a/packages/core/src/media/index.test.ts
+++ b/packages/core/src/media/index.test.ts
@@ -6,6 +6,7 @@ it('should expose correct exports', () => {
   expect(Object.keys(Exports)).toMatchInlineSnapshot(`
     [
       "canPlayMediaNatively",
+      "parseCid",
       "getMetricsReportingUrl",
       "MetricsStatus",
       "PlaybackMonitor",

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -1,4 +1,5 @@
 export { canPlayMediaNatively } from './browser';
+export { parseCid } from './decentralizedStorage';
 export {
   getMetricsReportingUrl,
   MetricsStatus,

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -125,7 +125,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
       const createdAsset = await this._create<
         StudioAsset,
         Omit<CreateAssetArgs, 'file'>
-      >('/asset/import', {
+      >('/asset/upload/url', {
         json: {
           name: args.name,
           url: args.url,

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -123,7 +123,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
   async createAsset(args: CreateAssetArgs): Promise<Asset> {
     if (args.url) {
       const createdAsset = await this._create<
-        StudioAsset,
+        { asset: StudioAsset },
         Omit<CreateAssetArgs, 'file'>
       >('/asset/upload/url', {
         json: {
@@ -133,7 +133,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
         headers: this._defaultHeaders,
       });
 
-      return this.getAsset(createdAsset?.id);
+      return this.getAsset(createdAsset?.asset?.id);
     }
 
     const uploadReq = await this._create<

--- a/packages/core/src/styling/controlsContainer.ts
+++ b/packages/core/src/styling/controlsContainer.ts
@@ -107,10 +107,32 @@ const left = css(spaceBetweenContainer, {
   width: 'auto',
 });
 
+const loadingText = css(sharedContainer, {
+  top: 0,
+  userSelect: 'none',
+  color: '$icon',
+
+  marginTop: '$controlsTopMarginY',
+  marginBottom: '$controlsTopMarginY',
+  marginLeft: '$controlsTopMarginX',
+  marginRight: '$controlsTopMarginX',
+
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  position: 'absolute',
+  textAlign: 'center',
+
+  left: 0,
+  right: 0,
+  bottom: 0,
+});
+
 export const controlsContainer = {
   background,
   gradient,
   loading,
+  loadingText,
 
   top: {
     container: topContainer,

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -151,10 +151,15 @@ export type AssetIdOrString =
 export type CreateAssetArgs = {
   /** Name for the new asset */
   name: string;
+
+  /** External URL to be imported */
+  url?: string;
+
   /** Content to be uploaded */
-  file: File | ReadStream;
+  file?: File | ReadStream;
   /** Size of the upload file. Must provide this if the file is a ReadStream */
   uploadSize?: number;
+
   /**
    * Callback to receive progress (0-1 completion ratio) updates of the upload.
    */
@@ -164,6 +169,9 @@ export type CreateAssetArgs = {
   | {
       file: ReadStream;
       uploadSize: number;
+    }
+  | {
+      url: string;
     }
 );
 

--- a/packages/react/src/components/media/Player.tsx
+++ b/packages/react/src/components/media/Player.tsx
@@ -20,7 +20,7 @@ import {
   Volume,
 } from './controls';
 import { Title } from './controls/Title';
-import { usePlaybackInfoOrImportIpfs } from './usePlaybackInfoOrImportIpfs';
+import { usePlaybackInfoOrImport } from './usePlaybackInfoOrImport';
 
 export type PlayerObjectFit = 'cover' | 'contain';
 
@@ -78,8 +78,8 @@ export type PlayerProps = {
   /** Whether to show the picture in picture button */
   showPipButton?: boolean;
 
-  /** If an IPFS CID or URL should automatically be imported as an Asset if playback info does not exist. Defaults to true. */
-  autoImportIpfs?: boolean;
+  /** If a decentralized identifier (an IPFS CID/URL) should automatically be imported as an Asset if playback info does not exist. Defaults to true. */
+  autoImport?: boolean;
 } & (
   | {
       src: string | string[] | null | undefined;
@@ -104,16 +104,16 @@ export function Player({
   aspectRatio = '16to9',
   objectFit = 'cover',
   showPipButton,
-  autoImportIpfs = true,
+  autoImport = true,
 }: PlayerProps) {
   const [mediaElement, setMediaElement] =
     React.useState<HTMLMediaElement | null>(null);
 
-  const playbackInfo = usePlaybackInfoOrImportIpfs(
+  const playbackInfo = usePlaybackInfoOrImport(
     src,
     playbackId,
     refetchPlaybackInfoInterval,
-    autoImportIpfs,
+    autoImport,
   );
 
   const [playbackUrls, setPlaybackUrls] = React.useState<string[]>([]);

--- a/packages/react/src/components/media/Player.tsx
+++ b/packages/react/src/components/media/Player.tsx
@@ -77,6 +77,9 @@ export type PlayerProps = {
 
   /** Whether to show the picture in picture button */
   showPipButton?: boolean;
+
+  /** If an IPFS CID or URL should automatically be imported as an Asset if playback info does not exist. Defaults to true. */
+  autoImportIpfs?: boolean;
 } & (
   | {
       src: string | string[] | null | undefined;
@@ -90,7 +93,7 @@ export function Player({
   controls,
   muted,
   playbackId,
-  refetchPlaybackInfoInterval = 5000,
+  refetchPlaybackInfoInterval = 10000,
   src,
   theme,
   title,
@@ -101,6 +104,7 @@ export function Player({
   aspectRatio = '16to9',
   objectFit = 'cover',
   showPipButton,
+  autoImportIpfs = true,
 }: PlayerProps) {
   const [mediaElement, setMediaElement] =
     React.useState<HTMLMediaElement | null>(null);
@@ -109,6 +113,7 @@ export function Player({
     src,
     playbackId,
     refetchPlaybackInfoInterval,
+    autoImportIpfs,
   );
 
   const [playbackUrls, setPlaybackUrls] = React.useState<string[]>([]);

--- a/packages/react/src/components/media/Player.tsx
+++ b/packages/react/src/components/media/Player.tsx
@@ -3,7 +3,6 @@ import { ControlsOptions } from 'livepeer/media/controls';
 import { AspectRatio, ThemeConfig } from 'livepeer/styling';
 import * as React from 'react';
 
-import { usePlaybackInfo } from '../../hooks';
 import { AudioPlayer } from './AudioPlayer';
 import { HlsPlayer } from './HlsPlayer';
 import { VideoPlayer } from './VideoPlayer';
@@ -21,6 +20,7 @@ import {
   Volume,
 } from './controls';
 import { Title } from './controls/Title';
+import { usePlaybackInfoOrImportIpfs } from './usePlaybackInfoOrImportIpfs';
 
 export type PlayerObjectFit = 'cover' | 'contain';
 
@@ -105,11 +105,12 @@ export function Player({
   const [mediaElement, setMediaElement] =
     React.useState<HTMLMediaElement | null>(null);
 
-  const { data: playbackInfo } = usePlaybackInfo({
-    playbackId: playbackId ?? undefined,
-    refetchInterval: (info) => (info ? false : refetchPlaybackInfoInterval),
-    enabled: !src && Boolean(playbackId),
-  });
+  const playbackInfo = usePlaybackInfoOrImportIpfs(
+    src,
+    playbackId,
+    refetchPlaybackInfoInterval,
+  );
+
   const [playbackUrls, setPlaybackUrls] = React.useState<string[]>([]);
 
   React.useEffect(() => {

--- a/packages/react/src/components/media/Player.tsx
+++ b/packages/react/src/components/media/Player.tsx
@@ -1,6 +1,7 @@
 import { AudioSrc, Src, VideoSrc, getMediaSourceType } from 'livepeer/media';
 import { ControlsOptions } from 'livepeer/media/controls';
 import { AspectRatio, ThemeConfig } from 'livepeer/styling';
+import { Asset } from 'livepeer/types';
 import * as React from 'react';
 
 import { AudioPlayer } from './AudioPlayer';
@@ -109,11 +110,28 @@ export function Player({
   const [mediaElement, setMediaElement] =
     React.useState<HTMLMediaElement | null>(null);
 
+  const [importStatus, setImportStatus] = React.useState<
+    Asset['status'] | null
+  >(null);
+
+  const onAssetStatusChange = React.useCallback(
+    (status: Asset['status']) => {
+      setImportStatus(status);
+    },
+    [setImportStatus],
+  );
+
   const playbackInfo = usePlaybackInfoOrImport(
     src,
     playbackId,
     refetchPlaybackInfoInterval,
     autoImport,
+    onAssetStatusChange,
+  );
+
+  const importProgress = React.useMemo(
+    () => importStatus?.progress,
+    [importStatus],
   );
 
   const [playbackUrls, setPlaybackUrls] = React.useState<string[]>([]);
@@ -223,6 +241,7 @@ export function Player({
             <ControlsContainer
               hidePosterOnPlayed={hidePosterOnPlayed}
               showLoadingSpinner={showLoadingSpinner}
+              importProgress={importProgress}
               poster={poster && <Poster content={poster} title={title} />}
               top={<>{title && showTitle && <Title content={title} />}</>}
               middle={<Progress />}

--- a/packages/react/src/components/media/controls/ControlsContainer.tsx
+++ b/packages/react/src/components/media/controls/ControlsContainer.tsx
@@ -1,5 +1,6 @@
 import { MediaControllerState } from 'livepeer/media/controls';
 import { styling } from 'livepeer/styling';
+import { isNumber } from 'livepeer/utils';
 import * as React from 'react';
 
 import { useMediaController } from '../context';
@@ -19,6 +20,7 @@ const mediaControllerSelector = ({
 });
 
 export type ControlsContainerProps = {
+  importProgress?: number;
   showLoadingSpinner?: boolean;
   hidePosterOnPlayed?: boolean;
   poster?: React.ReactNode;
@@ -41,6 +43,7 @@ export const ControlsContainer = React.forwardRef<
     poster,
     showLoadingSpinner = true,
     hidePosterOnPlayed = true,
+    importProgress,
   } = props;
 
   const { hidden, togglePlay, canPlay, hasPlayed, buffered } =
@@ -56,6 +59,14 @@ export const ControlsContainer = React.forwardRef<
       togglePlay();
     }
   }, [togglePlay, isLoaded]);
+
+  const loadingText = React.useMemo(
+    () =>
+      isNumber(importProgress)
+        ? `${(Number(importProgress) * 100).toFixed(0)}%`
+        : null,
+    [importProgress],
+  );
 
   return (
     <>
@@ -81,6 +92,10 @@ export const ControlsContainer = React.forwardRef<
           className={styling.controlsContainer.background()}
           onMouseUp={onClickBackground}
         >
+          <div className={styling.controlsContainer.loadingText()}>
+            {loadingText}
+          </div>
+
           <div className={styling.controlsContainer.loading()} />
         </div>
       )}

--- a/packages/react/src/components/media/usePlaybackInfoOrImport.tsx
+++ b/packages/react/src/components/media/usePlaybackInfoOrImport.tsx
@@ -13,11 +13,11 @@ import { PlayerProps } from './Player';
  * @param src Source URL for the media.
  * @param playbackId Playback ID of the media.
  */
-export const usePlaybackInfoOrImportIpfs = (
+export const usePlaybackInfoOrImport = (
   src: PlayerProps['src'],
   playbackId: PlayerProps['playbackId'],
   refetchPlaybackInfoInterval: number,
-  autoImportIpfs: boolean,
+  autoImport: boolean,
 ) => {
   const {
     mutate: importAsset,
@@ -63,7 +63,7 @@ export const usePlaybackInfoOrImportIpfs = (
     console.log({ playbackInfoError });
 
     if (
-      autoImportIpfs &&
+      autoImport &&
       ipfsSrcOrPlaybackId?.url &&
       ipfsSrcOrPlaybackId?.cid &&
       (playbackInfoError as HttpError)?.code === 404
@@ -73,7 +73,7 @@ export const usePlaybackInfoOrImportIpfs = (
         url: ipfsSrcOrPlaybackId.url,
       });
     }
-  }, [autoImportIpfs, ipfsSrcOrPlaybackId, playbackInfoError, importAsset]);
+  }, [autoImport, ipfsSrcOrPlaybackId, playbackInfoError, importAsset]);
 
   return playbackInfo;
 };

--- a/packages/react/src/components/media/usePlaybackInfoOrImportIpfs.tsx
+++ b/packages/react/src/components/media/usePlaybackInfoOrImportIpfs.tsx
@@ -17,6 +17,7 @@ export const usePlaybackInfoOrImportIpfs = (
   src: PlayerProps['src'],
   playbackId: PlayerProps['playbackId'],
   refetchPlaybackInfoInterval: number,
+  autoImportIpfs: boolean,
 ) => {
   const {
     mutate: importAsset,
@@ -34,7 +35,7 @@ export const usePlaybackInfoOrImportIpfs = (
   useAsset({
     assetId: importedAsset?.id,
     refetchInterval: (asset) =>
-      asset?.status?.phase !== 'ready' ? 5000 : false,
+      asset?.status?.phase !== 'ready' ? refetchPlaybackInfoInterval : false,
   });
 
   // check if the src or playbackId are IPFS sources (does not handle src arrays)
@@ -57,10 +58,12 @@ export const usePlaybackInfoOrImportIpfs = (
   });
 
   // trigger an import if the playback info had a 404 error and the asset is an IPFS source
+  // must be enabled
   React.useEffect(() => {
     console.log({ playbackInfoError });
 
     if (
+      autoImportIpfs &&
       ipfsSrcOrPlaybackId?.url &&
       ipfsSrcOrPlaybackId?.cid &&
       (playbackInfoError as HttpError)?.code === 404
@@ -70,7 +73,7 @@ export const usePlaybackInfoOrImportIpfs = (
         url: ipfsSrcOrPlaybackId.url,
       });
     }
-  }, [ipfsSrcOrPlaybackId, playbackInfoError, importAsset]);
+  }, [autoImportIpfs, ipfsSrcOrPlaybackId, playbackInfoError, importAsset]);
 
   return playbackInfo;
 };

--- a/packages/react/src/components/media/usePlaybackInfoOrImportIpfs.tsx
+++ b/packages/react/src/components/media/usePlaybackInfoOrImportIpfs.tsx
@@ -1,0 +1,76 @@
+import { HttpError } from 'livepeer';
+import { parseCid } from 'livepeer/media';
+
+import * as React from 'react';
+
+import { useAsset, useCreateAsset, usePlaybackInfo } from '../../hooks';
+import { PlayerProps } from './Player';
+
+/**
+ * Retrieves the playback info for a playback ID or source URL.
+ * Automatically imports a source URL from IPFS if it is a valid CID.
+ *
+ * @param src Source URL for the media.
+ * @param playbackId Playback ID of the media.
+ */
+export const usePlaybackInfoOrImportIpfs = (
+  src: PlayerProps['src'],
+  playbackId: PlayerProps['playbackId'],
+  refetchPlaybackInfoInterval: number,
+) => {
+  const {
+    mutate: importAsset,
+    data: importedAsset,
+    // status: importStatus,
+    // error: importError,
+  } = useCreateAsset();
+
+  // const {
+  //   data: asset,
+  //   error: assetError,
+  //   status: assetStatus,
+  // } =
+
+  useAsset({
+    assetId: importedAsset?.id,
+    refetchInterval: (asset) =>
+      asset?.status?.phase !== 'ready' ? 5000 : false,
+  });
+
+  // check if the src or playbackId are IPFS sources (does not handle src arrays)
+  const ipfsSrcOrPlaybackId = React.useMemo(
+    () =>
+      playbackId
+        ? parseCid(playbackId)
+        : !Array.isArray(src)
+        ? parseCid(src)
+        : null,
+    [playbackId, src],
+  );
+
+  console.log({ ipfsSrcOrPlaybackId });
+
+  const { data: playbackInfo, error: playbackInfoError } = usePlaybackInfo({
+    // attempt to fetch if the source is IPFS, or a playback ID is provided
+    playbackId: ipfsSrcOrPlaybackId?.cid ?? playbackId ?? undefined,
+    refetchInterval: (info) => (info ? false : refetchPlaybackInfoInterval),
+  });
+
+  // trigger an import if the playback info had a 404 error and the asset is an IPFS source
+  React.useEffect(() => {
+    console.log({ playbackInfoError });
+
+    if (
+      ipfsSrcOrPlaybackId?.url &&
+      ipfsSrcOrPlaybackId?.cid &&
+      (playbackInfoError as HttpError)?.code === 404
+    ) {
+      importAsset({
+        name: ipfsSrcOrPlaybackId.cid,
+        url: ipfsSrcOrPlaybackId.url,
+      });
+    }
+  }, [ipfsSrcOrPlaybackId, playbackInfoError, importAsset]);
+
+  return playbackInfo;
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,7 +4,12 @@ export {
   studioProvider,
   type StudioLivepeerProviderConfig,
 } from 'livepeer/providers/studio';
-export { defaultTheme, getCssText, styling } from 'livepeer/styling';
+export {
+  defaultTheme,
+  getCssText,
+  styling,
+  type ThemeConfig,
+} from 'livepeer/styling';
 export { createReactClient } from './client';
 export type { CreateReactClientConfig, ReactClient } from './client';
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,7 @@ importers:
       cross-fetch: ^3.1.5
       ethers: ^5.7.1
       hls.js: ^1.2.4
+      multiformats: ^10.0.2
       tus-js-client: ^3.0.1
       zustand: ^4.1.1
     dependencies:
@@ -229,6 +230,7 @@ importers:
       core-js: 3.25.5
       cross-fetch: 3.1.5
       hls.js: 1.2.4
+      multiformats: 10.0.2
       tus-js-client: 3.0.1
       zustand: 4.1.1
     devDependencies:
@@ -8954,6 +8956,11 @@ packages:
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
+
+  /multiformats/10.0.2:
+    resolution: {integrity: sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: false
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}


### PR DESCRIPTION
## Description

Added automatic fetching/importing of IPFS URLs to the Player.

An IPFS [v0 or v1 CID](https://docs.ipfs.tech/concepts/content-addressing/) or URL (such as `ipfs://<CID>`, `https://<CID>.ipfs.dweb.link/` or `https://cloudflare-ipfs.com/ipfs/<CID>`, _but cannot be a directory_) can be passed as the `src` or `playbackID` to the Player, and it will automatically detect if it is a valid CID and attempt to fetch the playback info for the CID. If the API does not have an Asset with the corresponding CID, the Player will automatically attempt to import the CID from IPFS, and then play the transcoded content back.
