### PR TITLE
fix: Round the duration to 1:00 instead of 0:60

### DIFF
--- a/.changeset/empty-experts-marry.md
+++ b/.changeset/empty-experts-marry.md
@@ -1,0 +1,7 @@
+---
+'@livepeer/react': minor
+---
+
+fix: rounded the duration to 1:00 instead of 0:60
+
+When a video is 59.9 seconds long, the duration is rounded to 1:00 instead of saying 00:60.

--- a/examples/_dev/src/pages/index.tsx
+++ b/examples/_dev/src/pages/index.tsx
@@ -11,9 +11,7 @@ const Page = () => {
       <hr />
       <Asset />
       <hr />
-      <Link href="/player">
-        <a>Demo Player</a>
-      </Link>
+      <Link href="/player">Demo Player</Link>
     </>
   );
 };

--- a/packages/react/src/components/media/controls/TimeDisplay.tsx
+++ b/packages/react/src/components/media/controls/TimeDisplay.tsx
@@ -23,10 +23,12 @@ const getFormattedMinutesAndSeconds = (valueInSeconds: number | null) => {
     !isNaN(valueInSeconds) &&
     isFinite(valueInSeconds)
   ) {
-    const minutes = Math.floor(valueInSeconds / 60);
-    const seconds = Math.round(valueInSeconds % 60);
+    const roundedValue = Math.round(valueInSeconds);
 
-    return `${minutes.toFixed(0)}:${seconds.toFixed(0).padStart(2, '0')}`;
+    const minutes = Math.floor(roundedValue / 60);
+    const seconds = Math.floor(roundedValue % 60);
+
+    return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
   }
 
   return `0:00`;


### PR DESCRIPTION
## Description

When a video is 59.9 seconds long, the duration is rounded to 1:00 instead of saying 00:60.

Closes #143

## Demo
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/56798748/200898261-f3052523-bcfa-4c42-b411-0a5f14d2cae2.png">

