### PR TITLE
fix: video pauses on second touch in mobile

### DIFF
--- a/.changeset/spotty-grapes-draw.md
+++ b/.changeset/spotty-grapes-draw.md
@@ -1,0 +1,5 @@
+---
+'@livepeer/react': minor
+---
+
+Fixed the behavior in which the video pauses when a user touches the video on mobile without the controls showing. Now the video on second touch (after the controls are shown).

--- a/.changeset/spotty-grapes-draw.md
+++ b/.changeset/spotty-grapes-draw.md
@@ -1,5 +1,6 @@
 ---
 '@livepeer/react': minor
+'@livepeer': minor
 ---
 
 Fixed the behaviour that caused the video to pause when a user touched it on a mobile device without the controls being shown. The video now pauses on the second touch (after the controls are shown).

--- a/.changeset/spotty-grapes-draw.md
+++ b/.changeset/spotty-grapes-draw.md
@@ -2,4 +2,4 @@
 '@livepeer/react': minor
 ---
 
-Fixed the behavior in which the video pauses when a user touches the video on mobile without the controls showing. Now the video on second touch (after the controls are shown).
+Fixed the behavior in which the video pauses when a user touches the video on mobile without the controls showing. Now the video pauses on second touch (after the controls are shown).

--- a/.changeset/spotty-grapes-draw.md
+++ b/.changeset/spotty-grapes-draw.md
@@ -2,4 +2,4 @@
 '@livepeer/react': minor
 ---
 
-Fixed the behavior in which the video pauses when a user touches the video on mobile without the controls showing. Now the video pauses on second touch (after the controls are shown).
+Fixed the behaviour that caused the video to pause when a user touched it on a mobile device without the controls being shown. The video now pauses on the second touch (after the controls are shown).

--- a/packages/core/src/media/controls/controls.ts
+++ b/packages/core/src/media/controls/controls.ts
@@ -222,7 +222,14 @@ export const createControllerStore = <TElement extends HTMLMediaElement>(
             hasPlayed: true,
           })),
         onPause: () => set(() => ({ playing: false, hidden: false })),
-        togglePlay: () => set(({ playing }) => ({ playing: !playing })),
+        togglePlay: () => {
+          const { hidden, setHidden, device } = store.getState();
+          if (hidden && device.isMobile) {
+            setHidden(false);
+          } else {
+            set(({ playing }) => ({ playing: !playing }));
+          }
+        },
         onProgress: (time) => set(() => ({ progress: getFilteredNaN(time) })),
         requestSeek: (time) =>
           set(({ duration }) => ({
@@ -568,7 +575,10 @@ const addEffectsToStore = <TElement extends HTMLMediaElement>(
           options.autohide &&
           current._lastInteraction !== prev._lastInteraction
         ) {
-          store.getState().setHidden(false);
+          const { device } = store.getState();
+          if (!device.isMobile) {
+            store.getState().setHidden(false);
+          }
 
           await delay(options.autohide);
 


### PR DESCRIPTION
## Description

This fixes the behavior in which the video pauses when a user touches the video on mobile without the controls showing

Closes #82

## Demo 

- Mobile 📱 

https://user-images.githubusercontent.com/56798748/200912676-1cba0c24-59ba-49af-933e-40e5cb38ca84.mov

- Desktop 💻 


https://user-images.githubusercontent.com/56798748/200912906-c879dff2-1a57-43dd-8940-c6d80d3e9264.mov


