### PR TITLE
fix: reverted file fingerprint

### DIFF
--- a/.changeset/selfish-coins-rule.md
+++ b/.changeset/selfish-coins-rule.md
@@ -1,0 +1,6 @@
+---
+'livepeer': patch
+'@livepeer/react': patch
+---
+
+**Fix:** fixed a bug with the same file not being able to be uploaded twice by the same client - reverted changes to the Tus fingerprint.

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -31,7 +31,6 @@ import {
 } from '../../types';
 
 import { BaseLivepeerProvider, LivepeerProviderFn } from '../base';
-import { fingerprint } from './fingerprint';
 import {
   StudioAsset,
   StudioAssetPatchPayload,
@@ -190,9 +189,9 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
                 ...((source as CreateAssetSourceFile) instanceof File
                   ? null
                   : { chunkSize: 5 * 1024 * 1024 }),
-                fingerprint: function (file: File & { exif?: any }) {
-                  return fingerprint(file);
-                },
+                // fingerprint: function (file: File & { exif?: any }) {
+                //   return fingerprint(file);
+                // },
                 onError: (error) => {
                   console.log('Failed because: ', error);
                 },


### PR DESCRIPTION
## Description

Fixed a bug with the same file not being able to be uploaded twice by the same client - reverted changes to the Tus fingerprint.
