### PR TITLE
Fix for automatic playback from IPFS to use w3s.link

### DIFF
--- a/.changeset/clever-walls-peel.md
+++ b/.changeset/clever-walls-peel.md
@@ -1,0 +1,5 @@
+---
+'@livepeer/react': patch
+---
+
+**Fix:** updated to use `w3s.link` as the default IPFS gateway for immediate playback from IPFS in the Player.

--- a/docs/pages/react/Player.en-US.mdx
+++ b/docs/pages/react/Player.en-US.mdx
@@ -493,8 +493,9 @@ export type PlayerProps = {
 
 Enables automatic upload and playback from decentralized storage providers. Currently supports IPFS CIDs and IPFS/Arweave URLs. Defaults to `true`.
 
-If `fallback` is specified, while the URL upload is being processed in the background, the video will start non-transcoded playback using the Cloudflare gateway for IPFS
-and the arweave.net gateway for Arweave. Once this finishes, the Player will switch to playing from the transcoded version.
+If `fallback` is specified, while the URL upload is being processed in the background, the video will start non-transcoded playback immediately
+(defaulting to `w3s.link` for IPFS and `arweave.net` for Arweave). Once this finishes, the Player will switch to playing from the transcoded version
+from the Livepeer provider.
 
 It is highly recommended for the best playback experience to upload from an Arweave/IPFS URL using `useCreateAsset` (with the format `ipfs://<CID>` or `ar://<HASH>`)
 before presenting the content to the user - the first view with automatic URL upload can take a few minutes, then it will be permanently

--- a/packages/react/src/components/media/Player.tsx
+++ b/packages/react/src/components/media/Player.tsx
@@ -108,7 +108,7 @@ export type PlayerProps = {
   | { playbackId: string | null | undefined }
 );
 
-const defaultIpfsGateway = 'https://cloudflare-ipfs.com';
+const defaultIpfsGateway = 'https://w3s.link';
 const defaultArweaveGateway = 'https://arweave.net';
 
 export function Player({


### PR DESCRIPTION
## Description

Updated to use `w3s.link` as the default IPFS gateway for immediate playback from IPFS in the Player.
