### PR TITLE
Remove * on .mp4 in useDropZone

### DIFF
--- a/docs/components/examples/Asset.tsx
+++ b/docs/components/examples/Asset.tsx
@@ -55,7 +55,7 @@ export const Asset = () => {
     isDragReject,
   } = useDropzone({
     accept: {
-      'video/*': ['*.mp4'],
+      'video/*': ['.mp4'],
     },
     maxFiles: 1,
     onDrop,

--- a/docs/pages/examples/react/view-asset.en-US.mdx
+++ b/docs/pages/examples/react/view-asset.en-US.mdx
@@ -82,7 +82,7 @@ export const CreateAndViewAsset = () => {
 
   const { getRootProps, getInputProps } = useDropzone({
     accept: {
-      'video/*': ['*.mp4'],
+      'video/*': ['.mp4'],
     },
     maxFiles: 1,
     onDrop,


### PR DESCRIPTION
## Description
Having the * in *.mp4 causes some people not to be able to select the file but only drag and drop.

_Concise description of proposed changes_

Remove * on .mp4 in useDropZone fixes the issue

## Additional Information
Error:
TypeError: Failed to execute 'showOpenFilePicker' on 'Window': Extension '*.mp4' must start with '.'.
<!--
Feel free to delete this section if you have read the contributing docs.
For how we use changesets: https://github.com/livepeer/livepeer.js/blob/main/.github/CONTRIBUTING.md#versioning
-->

- [ ] I read the [contributing docs](/livepeer/livepeer.js/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
