### PR TITLE
Changed default objectFit to contain

### DIFF
--- a/.changeset/eight-bats-relate.md
+++ b/.changeset/eight-bats-relate.md
@@ -1,0 +1,7 @@
+---
+'@livepeer/core-react': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** changed the default `objectFit` for the Player to be `contain` instead of `cover`.

--- a/docs/components/docs/player/SimplePlayer.tsx
+++ b/docs/components/docs/player/SimplePlayer.tsx
@@ -22,6 +22,7 @@ export const SimplePlayer = () => {
       playbackId="bafybeida3w2w7fch2fy6rfvfttqamlcyxgd3ddbf4u25n7fxzvyvcaegxy"
       poster={<PosterImage />}
       showPipButton
+      objectFit="cover"
     />
   );
 };

--- a/docs/pages/react/Player.en-US.mdx
+++ b/docs/pages/react/Player.en-US.mdx
@@ -53,6 +53,7 @@ was passed to the viewer.
           playbackId="6d7el73r1y12chxr"
           poster={<PosterImage />}
           showPipButton
+          objectFit="cover"
         />
       );
     };

--- a/packages/core-react/src/components/player/Player.tsx
+++ b/packages/core-react/src/components/player/Player.tsx
@@ -109,7 +109,7 @@ export const usePlayer = <TElement, TPoster>({
   showUploadingIndicator = true,
   showTitle = true,
   aspectRatio = '16to9',
-  objectFit = 'cover',
+  objectFit = 'contain',
   mediaElementRef,
 }: PlayerProps<TElement, TPoster>) => {
   const [mediaElement, setMediaElement] = React.useState<TElement | null>(null);


### PR DESCRIPTION
## Description

Changed the default `objectFit` for the Player to be `contain` instead of `cover`.
