### PR TITLE
usePlaybackInfo wasn't exported

### DIFF
--- a/.changeset/wise-moose-taste.md
+++ b/.changeset/wise-moose-taste.md
@@ -1,0 +1,7 @@
+---
+'@livepeer/core-react': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** added missing `usePlaybackInfo` export to React/React Native.

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -72,6 +72,7 @@ it('should expose correct exports', () => {
       "useCreateStream",
       "useLivepeerProvider",
       "useMediaController",
+      "usePlaybackInfo",
       "useStream",
       "useStreamSession",
       "useStreamSessions",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -62,6 +62,7 @@ export {
   useCreateAsset,
   useCreateStream,
   useLivepeerProvider,
+  usePlaybackInfo,
   useStream,
   useStreamSession,
   useStreamSessions,


### PR DESCRIPTION
## Description

usePlaybackInfo wasn't exported

## Additional Information

- [ ] I read the [contributing docs](/livepeer/livepeer.js/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
