### PR TITLE
fix: change metrics port

### DIFF
--- a/.changeset/wise-spiders-repair.md
+++ b/.changeset/wise-spiders-repair.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'livepeer': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** change the metrics reporting port for staging to use 443.

--- a/packages/core/src/media/metrics/utils.ts
+++ b/packages/core/src/media/metrics/utils.ts
@@ -46,7 +46,7 @@ export const getMetricsReportingUrl = async (
         : tld === 'fun'
         ? 'fun:20443'
         : tld === 'monster'
-        ? 'monster:10443'
+        ? 'monster'
         : null;
 
     // if not a known TLD, then do not return a URL

--- a/packages/core/src/providers/version.ts
+++ b/packages/core/src/providers/version.ts
@@ -1,3 +1,3 @@
-export const core = `@livepeer/core@1.1.3`;
-export const react = `@livepeer/react@2.1.3`;
-export const reactNative = `@livepeer/react-native@1.1.3`;
+export const core = `@livepeer/core@1.1.4`;
+export const react = `@livepeer/react@2.1.4`;
+export const reactNative = `@livepeer/react-native@1.1.4`;


### PR DESCRIPTION
## Description

Change the metrics reporting port for staging to use 443.

Closes #262 