### PR TITLE
fix: fixed passing of children as controls override

### DIFF
--- a/packages/core-react/src/components/player/controls/FullscreenButton.tsx
+++ b/packages/core-react/src/components/player/controls/FullscreenButton.tsx
@@ -28,10 +28,6 @@ export type FullscreenButtonProps = {
    * The size of the icon.
    */
   size?: number | string;
-  /**
-   * The styling overrides for the icon.
-   */
-  style?: React.CSSProperties;
 };
 
 type FullscreenButtonCoreProps = {

--- a/packages/core-react/src/components/player/controls/PlayButton.tsx
+++ b/packages/core-react/src/components/player/controls/PlayButton.tsx
@@ -28,10 +28,6 @@ export type PlayButtonProps = {
    * The size of the icon.
    */
   size?: number | string;
-  /**
-   * The styling overrides for the icon.
-   */
-  style?: React.CSSProperties;
 };
 
 type PlayButtonCoreProps = {

--- a/packages/core-react/src/components/player/controls/Volume.tsx
+++ b/packages/core-react/src/components/player/controls/Volume.tsx
@@ -36,10 +36,6 @@ export type VolumeProps = {
    * The size of the icon.
    */
   size?: number | string;
-  /**
-   * The styling overrides for the icon.
-   */
-  style?: React.CSSProperties;
 };
 
 type VolumeCoreProps = {

--- a/packages/core/src/providers/version.ts
+++ b/packages/core/src/providers/version.ts
@@ -1,3 +1,3 @@
 export const core = `@livepeer/core@1.2.1`;
-export const react = `@livepeer/react@2.2.3`;
-export const reactNative = `@livepeer/react-native@1.2.3`;
+export const react = `@livepeer/react@2.2.4-next.0`;
+export const reactNative = `@livepeer/react-native@1.2.4-next.0`;

--- a/packages/react-native/src/components/media/controls/FullscreenButton.tsx
+++ b/packages/react-native/src/components/media/controls/FullscreenButton.tsx
@@ -1,4 +1,4 @@
-import { MediaControllerState } from '@livepeer/core-react';
+import { MediaControllerState, omit } from '@livepeer/core-react';
 import {
   FullscreenButtonProps,
   useFullscreenButton,
@@ -64,12 +64,11 @@ export const FullscreenButton: React.FC<FullscreenButtonProps> = (props) => {
       style={{
         width: props.size,
         height: props.size,
-        ...props.style,
       }}
       size={{
         '@lg': 'large',
       }}
-      {...buttonProps}
+      {...omit(buttonProps, 'size')}
       accessibilityLabel={title}
     />
   );

--- a/packages/react-native/src/components/media/controls/PlayButton.tsx
+++ b/packages/react-native/src/components/media/controls/PlayButton.tsx
@@ -1,4 +1,4 @@
-import { MediaControllerState } from '@livepeer/core-react';
+import { MediaControllerState, omit } from '@livepeer/core-react';
 import {
   PlayButtonProps,
   usePlayButton,
@@ -50,12 +50,11 @@ export const PlayButton: React.FC<PlayButtonProps> = (props) => {
       style={{
         width: props.size,
         height: props.size,
-        ...props.style,
       }}
       size={{
         '@lg': 'large',
       }}
-      {...buttonProps}
+      {...omit(buttonProps, 'size')}
       accessibilityLabel={title}
     />
   );

--- a/packages/react-native/src/components/media/controls/Volume.tsx
+++ b/packages/react-native/src/components/media/controls/Volume.tsx
@@ -1,4 +1,4 @@
-import { MediaControllerState } from '@livepeer/core-react';
+import { MediaControllerState, omit } from '@livepeer/core-react';
 import { VolumeProps, useVolume } from '@livepeer/core-react/components';
 import * as React from 'react';
 
@@ -70,13 +70,12 @@ export const Volume: React.FC<VolumeProps> = (props) => {
         style={{
           width: props.size,
           height: props.size,
-          ...props.style,
         }}
         size={{
           '@lg': 'large',
         }}
         accessibilityLabel={title}
-        {...buttonProps}
+        {...omit(buttonProps, 'size')}
       />
     </VolumeContainer>
   );

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -13,9 +13,11 @@ export function createReactClient<TLivepeerProvider extends LivepeerProvider>({
   return createCoreReactClient({
     storage:
       typeof window !== 'undefined'
-        ? createStorage({
-            storage: window.localStorage,
-          })
+        ? config.storage
+          ? config.storage
+          : createStorage({
+              storage: window.localStorage,
+            })
         : undefined,
     ...config,
   });

--- a/packages/react/src/components/media/controls/ControlsContainer.tsx
+++ b/packages/react/src/components/media/controls/ControlsContainer.tsx
@@ -138,13 +138,15 @@ export const ControlsContainer: React.FC<ControlsContainerProps> = (props) => {
               </div>
             </div>
           </div>
-          <div
-            className={styling.controlsContainer.background({
-              display: hidden ? 'hidden' : 'shown',
-            })}
-          >
-            {children}
-          </div>
+          {children && (
+            <div
+              className={styling.controlsContainer.background({
+                display: hidden ? 'hidden' : 'shown',
+              })}
+            >
+              {children}
+            </div>
+          )}
         </>
       )}
     </>

--- a/packages/react/src/components/media/controls/FullscreenButton.tsx
+++ b/packages/react/src/components/media/controls/FullscreenButton.tsx
@@ -101,13 +101,12 @@ export const FullscreenButton: React.FC<FullscreenButtonProps> = (props) => {
       style={{
         width: props.size,
         height: props.size,
-        ...props.style,
       }}
       className={styling.iconButton()}
       title={title}
       aria-label={title}
       onClick={buttonProps.onPress}
-      {...omit(buttonProps, 'onPress')}
+      {...omit(buttonProps, 'onPress', 'size')}
     />
   );
 };

--- a/packages/react/src/components/media/controls/PlayButton.tsx
+++ b/packages/react/src/components/media/controls/PlayButton.tsx
@@ -57,13 +57,12 @@ export const PlayButton: React.FC<PlayButtonProps> = (props) => {
       style={{
         width: props.size,
         height: props.size,
-        ...props.style,
       }}
       className={styling.iconButton()}
       title={title}
       aria-label={title}
       onClick={buttonProps.onPress}
-      {...omit(buttonProps, 'onPress')}
+      {...omit(buttonProps, 'onPress', 'size')}
     />
   );
 };

--- a/packages/react/src/components/media/controls/Volume.tsx
+++ b/packages/react/src/components/media/controls/Volume.tsx
@@ -67,13 +67,12 @@ export const Volume: React.FC<VolumeProps> = (props) => {
         style={{
           width: props.size,
           height: props.size,
-          ...props.style,
         }}
         className={styling.iconButton()}
         title={title}
         aria-label={title}
         onClick={buttonProps.onPress}
-        {...omit(buttonProps, 'onPress')}
+        {...omit(buttonProps, 'onPress', 'size')}
       />
 
       {progressProps.shown && (


### PR DESCRIPTION
## Description

Fixed the controls `children` override to only display over other controls if present.