### PR TITLE
feat: remove livestream progress

### DIFF
--- a/.changeset/nice-badgers-prove.md
+++ b/.changeset/nice-badgers-prove.md
@@ -1,9 +1,0 @@
----
-'@livepeer/core': patch
-'@livepeer/core-react': patch
-'livepeer': patch
-'@livepeer/react': patch
-'@livepeer/react-native': patch
----
-
-**Fix:** fixed the player to not show buffering when playing livestreams.

--- a/.changeset/nice-badgers-prove.md
+++ b/.changeset/nice-badgers-prove.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'livepeer': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** fixed the player to not show buffering when playing livestreams.

--- a/.changeset/shy-bees-watch.md
+++ b/.changeset/shy-bees-watch.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'livepeer': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** fixed an error where HLS errors would not provide detail and the Player would throw an `object undefined` error.

--- a/.changeset/tough-donuts-peel.md
+++ b/.changeset/tough-donuts-peel.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': minor
+'@livepeer/core-react': minor
+'livepeer': minor
+'@livepeer/react': minor
+'@livepeer/react-native': minor
+---
+
+**Feature:** changed the Player on React and React Native to hide the progress bar when viewing a livestream. Also improved the live stream experience with better HLS.js defaults for lower latency.

--- a/examples/_expo/App.tsx
+++ b/examples/_expo/App.tsx
@@ -4,16 +4,10 @@ import {
   ThemeConfig,
   createReactClient,
   studioProvider,
-  useCreateAsset,
 } from '@livepeer/react-native';
-import {
-  ImagePickerAsset,
-  MediaTypeOptions,
-  launchImageLibraryAsync,
-} from 'expo-image-picker';
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
 
 const theme: ThemeConfig = {
   colors: {
@@ -43,64 +37,9 @@ export default function App() {
 }
 
 const VideoPlayer = () => {
-  const [video, setVideo] = useState<ImagePickerAsset | null>(null);
-
-  const pickImage = async () => {
-    const result = await launchImageLibraryAsync({
-      mediaTypes: MediaTypeOptions.Videos,
-      allowsEditing: true,
-    });
-
-    if (result?.assets?.[0]) {
-      setVideo(result?.assets?.[0]);
-    }
-  };
-
-  const {
-    mutate: createAsset,
-    data: assets,
-    progress,
-    status,
-    error,
-  } = useCreateAsset(
-    // we use a `const` assertion here to provide better Typescript types
-    // for the returned data
-    video
-      ? {
-          sources: [{ name: video.fileName ?? 'video', file: video }] as const,
-        }
-      : null,
-  );
-
-  useEffect(() => {
-    if (status === 'success') {
-      setVideo(null);
-    }
-  }, [status]);
-
   return (
     <>
-      <Button
-        title={!createAsset ? 'Pick a video from camera roll' : 'Begin upload'}
-        onPress={!createAsset ? pickImage : createAsset}
-        disabled={status === 'loading'}
-      />
-      {progress?.[0] && (
-        <Text style={styles.text}>
-          Upload: {progress?.[0]?.phase} -{' '}
-          {(progress?.[0]?.progress * 100).toFixed()}%
-        </Text>
-      )}
-      {error && <Text style={styles.text}>Error: {error.message}</Text>}
-      {assets?.[0]?.playbackId && (
-        <Player
-          title={assets?.[0]?.name}
-          aspectRatio="16to9"
-          playbackId={assets?.[0]?.playbackId}
-          autoPlay
-          loop
-        />
-      )}
+      <Player aspectRatio="16to9" playbackId="c8f8fw0j8ondyili" autoPlay loop />
     </>
   );
 };
@@ -109,9 +48,6 @@ const styles = StyleSheet.create({
   player: {
     alignContent: 'center',
     marginTop: 70,
-    textAlign: 'center',
-  },
-  text: {
     textAlign: 'center',
   },
 });

--- a/examples/_next/src/pages/simple-player.tsx
+++ b/examples/_next/src/pages/simple-player.tsx
@@ -3,7 +3,7 @@ import { Player } from '@livepeer/react';
 const Page = () => {
   return (
     <>
-      <Player playbackId="cc13p5jdxyyawul8" loop />
+      <Player autoPlay playbackId="c8f8fw0j8ondyili" loop />
     </>
   );
 };

--- a/packages/core-react/src/components/player/controls/Progress.tsx
+++ b/packages/core-react/src/components/player/controls/Progress.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 type ProgressStateSlice = Pick<
   MediaControllerState,
-  'duration' | 'progress' | 'requestSeek' | 'buffered'
+  'duration' | 'progress' | 'requestSeek' | 'buffered' | 'live'
 >;
 
 export type ProgressProps = {
@@ -29,7 +29,7 @@ export type ProgressProps = {
 type ProgressCoreProps = ProgressStateSlice & ProgressProps;
 
 export const useProgress = (props: ProgressCoreProps) => {
-  const { duration, progress, requestSeek, buffered, ...rest } = props;
+  const { duration, progress, requestSeek, buffered, live, ...rest } = props;
 
   const [min, max, current] = React.useMemo(
     () =>
@@ -62,6 +62,7 @@ export const useProgress = (props: ProgressCoreProps) => {
   );
 
   return {
+    isVisible: !live,
     title: `progress of ${durationMinutes} minutes`,
     progressProps: {
       onChange,

--- a/packages/core-web/src/media/browser/hls/index.ts
+++ b/packages/core-web/src/media/browser/hls/index.ts
@@ -55,6 +55,8 @@ export const createNewHls = <TElement extends HTMLMediaElement>(
   const hls = new Hls({
     maxBufferLength: 15,
     maxMaxBufferLength: 60,
+    liveMaxLatencyDurationCount: 7,
+    liveSyncDurationCount: 3,
     ...config,
   });
 

--- a/packages/core-web/src/media/browser/styling/time.ts
+++ b/packages/core-web/src/media/browser/styling/time.ts
@@ -1,7 +1,20 @@
+import { keyframes } from '@stitches/core';
+
 import { css } from './stitches';
 import { text } from './text';
 
+export const pulse = keyframes({
+  '0%, 100%': {
+    opacity: 1,
+  },
+  '50%': {
+    opacity: 0.5,
+  },
+});
+
 export const container = css('div', {
+  marginLeft: '$timeMarginX',
+  marginRight: '$timeMarginX',
   display: 'flex',
   alignItems: 'center',
 });
@@ -12,6 +25,8 @@ export const liveIndicator = css('div', {
 
   width: '$liveIndicatorSize',
   height: '$liveIndicatorSize',
+
+  animation: `${pulse} 2s cubic-bezier(0.4, 0, 0.6, 1) infinite`,
 });
 
 export const timeText = css(text, {

--- a/packages/core/src/providers/version.ts
+++ b/packages/core/src/providers/version.ts
@@ -1,3 +1,3 @@
-export const core = `@livepeer/core@1.2.1`;
-export const react = `@livepeer/react@2.2.4-next.1`;
-export const reactNative = `@livepeer/react-native@1.2.4-next.1`;
+export const core = `@livepeer/core@1.2.3`;
+export const react = `@livepeer/react@2.2.5`;
+export const reactNative = `@livepeer/react-native@1.2.5`;

--- a/packages/react-native/src/components/media/controls/Progress.tsx
+++ b/packages/react-native/src/components/media/controls/Progress.tsx
@@ -9,11 +9,13 @@ import { MediaElement } from '../types';
 const mediaControllerSelector = ({
   duration,
   progress,
+  live,
   requestSeek,
   buffered,
 }: MediaControllerState<MediaElement>) => ({
   duration,
   progress,
+  live,
   requestSeek,
   buffered,
 });
@@ -21,17 +23,17 @@ const mediaControllerSelector = ({
 export type { ProgressProps };
 
 export const Progress: React.FC<ProgressProps> = (props) => {
-  const { duration, progress, requestSeek, buffered } = useMediaController(
-    mediaControllerSelector,
-  );
+  const { duration, progress, requestSeek, live, buffered } =
+    useMediaController(mediaControllerSelector);
 
-  const { progressProps, title } = useProgress({
+  const { isVisible, progressProps, title } = useProgress({
     duration,
     progress,
     requestSeek,
     buffered,
+    live,
     ...props,
   });
 
-  return <BaseSlider {...progressProps} ariaName={title} />;
+  return isVisible ? <BaseSlider {...progressProps} ariaName={title} /> : <></>;
 };

--- a/packages/react-native/src/components/media/controls/TimeDisplay.tsx
+++ b/packages/react-native/src/components/media/controls/TimeDisplay.tsx
@@ -30,15 +30,16 @@ export const TimeDisplay: React.FC = () => {
 
   return (
     <>
-      <TimeText
-        size={{
-          '@md': 'medium',
-          '@lg': 'large',
-        }}
-      >
-        {title}
-      </TimeText>
-      {isLive && (
+      {!isLive ? (
+        <TimeText
+          size={{
+            '@md': 'medium',
+            '@lg': 'large',
+          }}
+        >
+          {title}
+        </TimeText>
+      ) : (
         <TimeContainer accessibilityLabel="Live streaming media">
           <TimeLiveIndicator />
           <TimeText

--- a/packages/react-native/src/components/media/controls/Volume.tsx
+++ b/packages/react-native/src/components/media/controls/Volume.tsx
@@ -67,10 +67,6 @@ export const Volume: React.FC<VolumeProps> = (props) => {
   return (
     <VolumeContainer>
       <IconButton
-        style={{
-          width: props.size,
-          height: props.size,
-        }}
         size={{
           '@lg': 'large',
         }}

--- a/packages/react-native/src/components/media/players/VideoPlayer.tsx
+++ b/packages/react-native/src/components/media/players/VideoPlayer.tsx
@@ -30,7 +30,7 @@ import { MediaControllerContext } from '../../../context';
 import { PosterSource } from '../Player';
 import { MediaElement } from '../types';
 
-const defaultProgressUpdateInterval = 20;
+const defaultProgressUpdateInterval = 100;
 
 export type VideoPlayerProps = VideoPlayerCoreProps<
   MediaElement,
@@ -131,6 +131,8 @@ export const VideoPlayer = React.forwardRef<MediaElement, VideoPlayerProps>(
             buffered: status.playableDurationMillis
               ? status.playableDurationMillis / 1000
               : buffered,
+
+            live: !status.durationMillis,
 
             isVolumeChangeSupported: true,
 

--- a/packages/react-native/src/components/styling/time.ts
+++ b/packages/react-native/src/components/styling/time.ts
@@ -5,6 +5,7 @@ import { text } from './text';
 
 export const TimeContainer = styled(View, {
   display: 'flex',
+  flexDirection: 'row',
   alignItems: 'center',
 });
 

--- a/packages/react/src/components/media/controls/PlaybackDisplayError.tsx
+++ b/packages/react/src/components/media/controls/PlaybackDisplayError.tsx
@@ -11,7 +11,7 @@ export const OfflineStreamError: React.FC = () => (
       Stream is offline
     </div>
     <div className={styling.controlsContainer.error.text()}>
-      Playback will start automatically once stream has started.
+      Playback will start automatically once the stream has started.
     </div>
   </div>
 );

--- a/packages/react/src/components/media/controls/Progress.tsx
+++ b/packages/react/src/components/media/controls/Progress.tsx
@@ -10,27 +10,29 @@ const mediaControllerSelector = ({
   progress,
   requestSeek,
   buffered,
+  live,
 }: MediaControllerState<HTMLMediaElement>) => ({
   duration,
   progress,
   requestSeek,
   buffered,
+  live,
 });
 
 export type { ProgressProps };
 
 export const Progress: React.FC<ProgressProps> = (props) => {
-  const { duration, progress, requestSeek, buffered } = useMediaController(
-    mediaControllerSelector,
-  );
+  const { duration, progress, requestSeek, buffered, live } =
+    useMediaController(mediaControllerSelector);
 
-  const { progressProps, title } = useProgress({
+  const { isVisible, progressProps, title } = useProgress({
     duration,
     progress,
     requestSeek,
     buffered,
+    live,
     ...props,
   });
 
-  return <BaseSlider {...progressProps} ariaName={title} />;
+  return isVisible ? <BaseSlider {...progressProps} ariaName={title} /> : <></>;
 };

--- a/packages/react/src/components/media/controls/TimeDisplay.tsx
+++ b/packages/react/src/components/media/controls/TimeDisplay.tsx
@@ -28,10 +28,11 @@ export const TimeDisplay: React.FC = () => {
 
   return (
     <>
-      <span className={styling.time.text()} aria-label={'Playback time'}>
-        {title}
-      </span>
-      {isLive && (
+      {!isLive ? (
+        <span className={styling.time.text()} aria-label={'Playback time'}>
+          {title}
+        </span>
+      ) : (
         <div className={styling.time.container()}>
           <div className={styling.time.liveIndicator()} />
           <span

--- a/packages/react/src/components/media/players/VideoPlayer.tsx
+++ b/packages/react/src/components/media/players/VideoPlayer.tsx
@@ -100,7 +100,9 @@ export const VideoPlayer = React.forwardRef<HTMLVideoElement, VideoPlayerProps>(
         };
 
         const onError = (error: HlsError) => {
-          const cleanError = new Error(error.response?.data.toString());
+          const cleanError = new Error(
+            error?.response?.data?.toString?.() ?? 'Error with HLS.js',
+          );
           if (isStreamOfflineError(cleanError)) {
             onStreamStatusChange?.(false);
           } else if (isAccessControlError(cleanError)) {


### PR DESCRIPTION
## Description

Changed the Player on React and React Native to hide the progress bar when viewing a livestream. Also improved the live stream experience with better HLS.js defaults for lower latency.

Also fixed random bugs across the SDK.

Fixes https://linear.app/livepeer/issue/DX-3/clicking-live-in-the-player-should-take-you-to-the-current-live
Fixes https://linear.app/livepeer/issue/DX-21/seekbar-jumps-around-should-stay-pinned-to-the-right-unless-dvr-ing