### PR TITLE
Add upload to IPFS on create

### DIFF
--- a/.changeset/slow-kids-deliver.md
+++ b/.changeset/slow-kids-deliver.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'livepeer': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Feature:** added IPFS upload on creation of an asset, so no subsequent calls need to be made to upload to IPFS.

--- a/examples/_next/src/components/AssetDemoPlayer.tsx
+++ b/examples/_next/src/components/AssetDemoPlayer.tsx
@@ -17,12 +17,23 @@ export const AssetDemoPlayer = () => {
     progress,
     error,
   } = useCreateAsset({
-    sources: videos.map((video) => ({
-      name: video.name ?? 'Cool Video',
-      file: video,
-      storage: {},
-    })),
+    sources: videos.map(
+      (video) =>
+        ({
+          name: video.name ?? 'Cool Video',
+          file: video,
+          storage: {
+            ipfs: true,
+            metadata: {
+              name: 'interesting video',
+              description: 'overridden',
+            },
+          },
+        } as const),
+    ),
   });
+
+  console.log(assets);
 
   const onSourceUpdated = useCallback(
     (sources: Src[]) =>

--- a/examples/_next/src/components/AssetDemoPlayer.tsx
+++ b/examples/_next/src/components/AssetDemoPlayer.tsx
@@ -20,6 +20,7 @@ export const AssetDemoPlayer = () => {
     sources: videos.map((video) => ({
       name: video.name ?? 'Cool Video',
       file: video,
+      storage: {},
     })),
   });
 

--- a/examples/_next/src/pages/_app.tsx
+++ b/examples/_next/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import { publicProvider } from 'wagmi/providers/public';
 const livepeerClient = createReactClient({
   provider: studioProvider({
     apiKey: process.env.NEXT_PUBLIC_STUDIO_API_KEY ?? '',
+    baseUrl: 'https://livepeer.monster/api',
   }),
 });
 

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -3,6 +3,8 @@ import * as tus from 'tus-js-client';
 import {
   StudioAsset,
   StudioAssetPatchPayload,
+  StudioCreateAssetArgs,
+  StudioCreateAssetUrlArgs,
   StudioCreateStreamArgs,
   StudioPlaybackInfo,
   StudioStream,
@@ -154,11 +156,22 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
         if ((source as CreateAssetSourceUrl).url) {
           const createdAsset = await this._create<
             { asset: StudioAsset },
-            CreateAssetSourceUrl
+            StudioCreateAssetUrlArgs
           >('/asset/upload/url', {
             json: {
               name: source.name,
               url: (source as CreateAssetSourceUrl).url,
+              storage: source?.storage?.ipfs
+                ? {
+                    ipfs: {
+                      spec: {
+                        nftMetadata: source?.storage?.metadata ?? {},
+                        nftMetadataTemplate:
+                          source?.storage?.metadataTemplate ?? 'player',
+                      },
+                    },
+                  }
+                : undefined,
             },
             headers: this._defaultHeaders,
           });
@@ -167,10 +180,21 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
         } else {
           const uploadReq = await this._create<
             { tusEndpoint: string; asset: { id: string } },
-            { name: string }
+            StudioCreateAssetArgs
           >('/asset/request-upload', {
             json: {
               name: source.name,
+              storage: source?.storage?.ipfs
+                ? {
+                    ipfs: {
+                      spec: {
+                        nftMetadata: source?.storage?.metadata ?? {},
+                        nftMetadataTemplate:
+                          source?.storage?.metadataTemplate ?? 'player',
+                      },
+                    },
+                  }
+                : undefined,
             },
             headers: this._defaultHeaders,
           });

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -166,8 +166,12 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
                     ipfs: {
                       spec: {
                         nftMetadata: source?.storage?.metadata ?? {},
-                        nftMetadataTemplate:
-                          source?.storage?.metadataTemplate ?? 'player',
+                        ...(source?.storage?.metadataTemplate
+                          ? {
+                              nftMetadataTemplate:
+                                source.storage.metadataTemplate,
+                            }
+                          : {}),
                       },
                     },
                   }
@@ -189,8 +193,12 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
                     ipfs: {
                       spec: {
                         nftMetadata: source?.storage?.metadata ?? {},
-                        nftMetadataTemplate:
-                          source?.storage?.metadataTemplate ?? 'player',
+                        ...(source?.storage?.metadataTemplate
+                          ? {
+                              nftMetadataTemplate:
+                                source.storage.metadataTemplate,
+                            }
+                          : {}),
                       },
                     },
                   }
@@ -397,7 +405,11 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
                 ipfs: {
                   spec: {
                     nftMetadata: storage?.metadata ?? {},
-                    nftMetadataTemplate: storage?.metadataTemplate ?? 'player',
+                    ...(storage?.metadataTemplate
+                      ? {
+                          nftMetadataTemplate: storage.metadataTemplate,
+                        }
+                      : {}),
                   },
                 },
               }

--- a/packages/core/src/providers/studio/types.ts
+++ b/packages/core/src/providers/studio/types.ts
@@ -52,30 +52,52 @@ export type StudioStreamSetActivePayload = {
   [k: string]: unknown;
 };
 
+export type StudioStorageConfig = {
+  ipfs?:
+    | {
+        spec?: null | {
+          /**
+           * Name of the NFT metadata template to export. 'player' will embed the Livepeer Player on the NFT while 'file' will reference only the immutable MP4 files.
+           */
+          nftMetadataTemplate?: 'player' | 'file';
+          /**
+           * Additional data to add to the NFT metadata exported to IPFS. Will be deep merged with the default metadata exported.
+           */
+          nftMetadata?: {
+            [k: string]: unknown;
+          };
+        };
+      }
+    | (boolean | null);
+};
+
 export type StudioAssetPatchPayload = {
   /**
    * Name of the asset. This is not necessarily the filename, can be a custom name or title
    */
   name?: string;
   /** Storage configs for the asset */
-  storage?: {
-    ipfs?:
-      | {
-          spec?: null | {
-            /**
-             * Name of the NFT metadata template to export. 'player' will embed the Livepeer Player on the NFT while 'file' will reference only the immutable MP4 files.
-             */
-            nftMetadataTemplate?: 'player' | 'file';
-            /**
-             * Additional data to add to the NFT metadata exported to IPFS. Will be deep merged with the default metadata exported.
-             */
-            nftMetadata?: {
-              [k: string]: unknown;
-            };
-          };
-        }
-      | (boolean | null);
-  };
+  storage?: StudioStorageConfig;
+};
+
+export type StudioCreateAssetArgs = {
+  /**
+   * Name of the asset. This is not necessarily the filename, can be a custom name or title
+   */
+  name: string;
+  /** Storage configs for the asset */
+  storage?: StudioStorageConfig;
+};
+
+export type StudioCreateAssetUrlArgs = {
+  /**
+   * Name of the asset. This is not necessarily the filename, can be a custom name or title
+   */
+  name: string;
+  /** External URL to be imported */
+  url: string;
+  /** Storage configs for the asset */
+  storage?: StudioStorageConfig;
 };
 
 export interface StudioCreateStreamArgs extends CreateStreamArgs {

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -243,7 +243,9 @@ export type CreateAssetSourceFile = CreateAssetSourceBase & {
 
 export type CreateAssetSource = CreateAssetSourceFile | CreateAssetSourceUrl;
 
-export type CreateAssetSourceType = Array<CreateAssetSource>;
+export type CreateAssetSourceType =
+  | ReadonlyArray<CreateAssetSource>
+  | Array<CreateAssetSource>;
 
 export type CreateAssetArgs<TSource extends CreateAssetSourceType> = {
   /** Source(s) to upload */

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -194,9 +194,35 @@ export type CreateAssetProgress<TSource extends CreateAssetSourceType> = {
     : CreateAssetFileProgress;
 };
 
+export type StorageConfig = {
+  /**
+   * If the asset should be stored on IPFS.
+   */
+  ipfs?: boolean;
+  /**
+   * Metadata exported to the storage provider. This will be deep merged with the default
+   * metadata from the livepeer provider. This should ideally be EIP-721/EIP-1155 compatible.
+   *
+   * @see {@link https://eips.ethereum.org/EIPS/eip-721}
+   */
+  metadata?:
+    | Partial<Metadata> & {
+        [k: string]: unknown;
+      };
+  /**
+   * The NFT metadata template to use. `player` will embed the Livepeer Player's IPFS CID on the NFT while `file`
+   * will reference only the immutable media files.
+   */
+  metadataTemplate?: 'player' | 'file';
+};
+
 export type CreateAssetSourceBase = {
   /** Name for the new asset */
   name: string;
+  /**
+   * The storage configs to use for the asset. This also includes EIP-721 or EIP-1155 compatible NFT metadata configs.
+   */
+  storage?: StorageConfig;
 };
 
 export type CreateAssetSourceUrl = CreateAssetSourceBase & {
@@ -217,9 +243,7 @@ export type CreateAssetSourceFile = CreateAssetSourceBase & {
 
 export type CreateAssetSource = CreateAssetSourceFile | CreateAssetSourceUrl;
 
-export type CreateAssetSourceType =
-  | ReadonlyArray<CreateAssetSource>
-  | Array<CreateAssetSource>;
+export type CreateAssetSourceType = Array<CreateAssetSource>;
 
 export type CreateAssetArgs<TSource extends CreateAssetSourceType> = {
   /** Source(s) to upload */
@@ -278,27 +302,7 @@ export type UpdateAssetArgs = {
   /**
    * The storage configs to use for the asset. This also includes EIP-721 or EIP-1155 compatible NFT metadata configs.
    */
-  storage?: {
-    /**
-     * If the asset should be stored on IPFS.
-     */
-    ipfs?: boolean;
-    /**
-     * Metadata exported to the storage provider. This will be deep merged with the default
-     * metadata from the livepeer provider. This should ideally be EIP-721/EIP-1155 compatible.
-     *
-     * @see {@link https://eips.ethereum.org/EIPS/eip-721}
-     */
-    metadata?:
-      | Partial<Metadata> & {
-          [k: string]: unknown;
-        };
-    /**
-     * The NFT metadata template to use. `player` will embed the Livepeer Player's IPFS CID on the NFT while `file`
-     * will reference only the immutable media files.
-     */
-    metadataTemplate?: 'player' | 'file';
-  };
+  storage?: StorageConfig;
 } & (
   | {
       name: string;


### PR DESCRIPTION
## Description

Added IPFS upload on creation of an asset, so no subsequent calls need to be made to upload to IPFS.

Related to https://github.com/livepeer/docs/pull/355

Fixes https://linear.app/livepeer/issue/DX-104/add-upload-to-ipfs-in-usecreateasset