### PR TITLE
feat: add autoplay w/o mute

### DIFF
--- a/.changeset/cuddly-glasses-watch.md
+++ b/.changeset/cuddly-glasses-watch.md
@@ -1,0 +1,8 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'livepeer': patch
+'@livepeer/react': patch
+---
+
+**Feature:** added the ability to autoplay videos without forcing mute. This works only in certain conditions where the site is considered "trusted" and the user has interacted with the site - see [Chrome](https://developer.chrome.com/blog/autoplay/) and [Safari](https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/) docs for further details on when this is allowed. We recommend testing on your site to ensure that the media will autoplay under the conditions that you expect the user to engage with your content.

--- a/.changeset/tricky-singers-walk.md
+++ b/.changeset/tricky-singers-walk.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'livepeer': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** changed the default Player volume level to 1.0, from 0.2. To continue with the previous behavior, use `defaultVolume` in the [controls](https://docs.livepeer.org/reference/livepeer-js/Player#controls) prop.

--- a/examples/_next/src/components/AssetDemoPlayer.tsx
+++ b/examples/_next/src/components/AssetDemoPlayer.tsx
@@ -33,8 +33,6 @@ export const AssetDemoPlayer = () => {
     ),
   });
 
-  console.log(assets);
-
   const onSourceUpdated = useCallback(
     (sources: Src[]) =>
       setSources((prev) => new Set([...prev, sources?.[0]?.src])),

--- a/examples/_next/src/pages/simple-player.tsx
+++ b/examples/_next/src/pages/simple-player.tsx
@@ -3,7 +3,7 @@ import { Player } from '@livepeer/react';
 const Page = () => {
   return (
     <>
-      <Player autoPlay playbackId="c8f8fw0j8ondyili" loop />
+      <Player autoPlay playbackId="20137hphfd2isni4" loop />
     </>
   );
 };

--- a/packages/core-react/src/components/player/Player.tsx
+++ b/packages/core-react/src/components/player/Player.tsx
@@ -51,8 +51,7 @@ export type PlayerProps<TElement, TPoster> = {
   /** Configuration for the event listeners */
   controls?: ControlsOptions;
   /**
-   * Play media automatically when the content loads (if this is specified, you must also specify muted,
-   * since this is required in browsers)
+   * Play media automatically when the content loads
    */
   autoPlay?: boolean;
   /** Mute media by default */
@@ -248,7 +247,7 @@ export const usePlayer = <TElement, TPoster>(
     playerProps: {
       ref: playerRef,
       autoPlay,
-      muted: autoPlay ? true : muted,
+      muted,
       poster: poster,
       loop: loop,
       objectFit: objectFit,

--- a/packages/core-web/src/media/browser/controls/controller.ts
+++ b/packages/core-web/src/media/browser/controls/controller.ts
@@ -80,11 +80,13 @@ export const addEventListeners = <TElement extends HTMLMediaElement>(
   const initializedState = store.getState();
 
   // restore the persisted values from store
-  if (element && !element.muted && !element.defaultMuted) {
-    element.volume = initializedState.volume;
+  if (element) {
+    setTimeout(() => {
+      if (element && !store.getState().muted) {
+        store.getState().requestVolume(initializedState.volume);
+      }
+    }, 1);
   }
-
-  store.setState({ muted: element?.muted });
 
   const onCanPlay = () => store.getState().onCanPlay();
 
@@ -359,8 +361,9 @@ const addEffectsToStore = <TElement extends HTMLMediaElement>(
           element.volume = current.volume;
         }
 
+        element.muted = current.muted;
+
         if (current.muted !== prev.muted) {
-          element.muted = current.muted;
           if (current.volume === 0) {
             element.volume = DEFAULT_VOLUME_LEVEL;
           }

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -5,7 +5,7 @@ import { Src } from './src';
 import { ClientStorage } from '../storage';
 
 const DEFAULT_SEEK_TIME = 5000; // milliseconds which the media will skip when seeking with arrows/buttons
-export const DEFAULT_VOLUME_LEVEL = 0.2; // 0-1 for how loud the audio is
+export const DEFAULT_VOLUME_LEVEL = 1; // 0-1 for how loud the audio is
 
 export const DEFAULT_AUTOHIDE_TIME = 3000; // milliseconds to wait before hiding controls
 

--- a/packages/core/src/providers/version.ts
+++ b/packages/core/src/providers/version.ts
@@ -1,3 +1,3 @@
-export const core = `@livepeer/core@1.2.3`;
-export const react = `@livepeer/react@2.2.5`;
-export const reactNative = `@livepeer/react-native@1.2.5`;
+export const core = `@livepeer/core@1.3.1`;
+export const react = `@livepeer/react@2.3.1`;
+export const reactNative = `@livepeer/react-native@1.3.1`;


### PR DESCRIPTION
## Description

Added the ability to autoplay videos without forcing mute. This works only in certain conditions where the site is considered "trusted" and the user has interacted with the site - see [Chrome](https://developer.chrome.com/blog/autoplay/) and [Safari](https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/) docs for further details on when this is allowed. We recommend testing on your site to ensure that the media will autoplay under the conditions that you expect the user to engage with your content.

Fixes https://linear.app/livepeer/issue/DX-110/add-autoplay-without-forcing-mute