### PR TITLE
Fix iframe url

### DIFF
--- a/.changeset/four-squids-fly.md
+++ b/.changeset/four-squids-fly.md
@@ -1,0 +1,8 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'@livepeer/react': patch
+'livepeer': patch
+---
+
+**Fix:** updated the metrics to send the `pageUrl` as the `document.referrer` when used in an iFrame context, to be able to attribute metrics to a page which uses an iFrame.

--- a/packages/core/src/media/metrics/metrics.ts
+++ b/packages/core/src/media/metrics/metrics.ts
@@ -190,6 +190,15 @@ export class MetricsStatus<TElement> {
 
     this.store = store;
 
+    const windowHref =
+      typeof window !== 'undefined' ? window?.location?.href ?? '' : '';
+
+    const pageUrl = windowHref?.includes('lvpr.tv')
+      ? typeof document !== 'undefined'
+        ? document?.referrer ?? windowHref
+        : ''
+      : windowHref;
+
     this.currentMetrics = {
       autoplay:
         currentState.priority && currentState.autoplay
@@ -204,8 +213,7 @@ export class MetricsStatus<TElement> {
       nError: 0,
       nStalled: 0,
       nWaiting: 0,
-      pageUrl:
-        typeof window !== 'undefined' ? window?.location?.href ?? '' : '',
+      pageUrl,
       playbackScore: null,
       player: 'livepeer-js',
       playerHeight: null,


### PR DESCRIPTION
## Description

Updated the metrics to send the `pageUrl` as the `document.referrer` when used in an iFrame context, to be able to attribute metrics to a page which uses an iFrame.
