### PR TITLE
fix: fixed access control error

### DIFF
--- a/.changeset/orange-pots-arrive.md
+++ b/.changeset/orange-pots-arrive.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'@livepeer/react': patch
+'livepeer': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** fixed access control error not resetting when livestream starts.

--- a/packages/core-react/src/components/player/Player.tsx
+++ b/packages/core-react/src/components/player/Player.tsx
@@ -182,11 +182,15 @@ export const usePlayer = <
     React.useState<Error | null>(null);
 
   const accessControlErrorCallback = React.useCallback(
-    (error: Error) => {
+    (error: Error | null) => {
       if (!accessControlError) {
         setAccessControlError(error);
       }
-      onAccessControlError?.(error);
+      if (!error) {
+        setAccessControlError(null);
+      } else {
+        onAccessControlError?.(error);
+      }
     },
     [onAccessControlError, accessControlError],
   );

--- a/packages/core-react/src/components/player/players.tsx
+++ b/packages/core-react/src/components/player/players.tsx
@@ -31,7 +31,7 @@ export type VideoPlayerProps<
   options?: ControlsOptions;
   onStreamStatusChange?: (isLive: boolean) => void;
   onMetricsError?: (error: Error) => void;
-  onAccessControlError?: (error: Error) => void;
+  onAccessControlError?: (error: Error | null) => void;
   onError?: (error: Error) => void;
 };
 

--- a/packages/core/src/providers/version.ts
+++ b/packages/core/src/providers/version.ts
@@ -1,3 +1,3 @@
-export const core = `@livepeer/core@1.3.2`;
-export const react = `@livepeer/react@2.3.2`;
-export const reactNative = `@livepeer/react-native@1.3.2`;
+export const core = `@livepeer/core@1.4.1`;
+export const react = `@livepeer/react@2.4.1`;
+export const reactNative = `@livepeer/react-native@1.4.1`;

--- a/packages/react/src/components/media/players/VideoPlayer.tsx
+++ b/packages/react/src/components/media/players/VideoPlayer.tsx
@@ -101,6 +101,7 @@ export const VideoPlayer = React.forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
       if (element && shouldUseHlsjs) {
         const onLive = (fullscreen: boolean) => {
+          onAccessControlError?.(null);
           onStreamStatusChange?.(true);
           store.getState().setLive(fullscreen);
         };
@@ -142,6 +143,7 @@ export const VideoPlayer = React.forwardRef<HTMLVideoElement, VideoPlayerProps>(
         );
 
         return () => {
+          onAccessControlError?.(null);
           destroy();
         };
       }


### PR DESCRIPTION
## Description

Fixed access control error not resetting when livestream starts.

Fixes https://linear.app/livepeer/issue/PRO-24/player-displays-auth-error-on-a-stream-with-no-auth
