### PR TITLE
Add creator id to create asset

### DIFF
--- a/.changeset/heavy-dolphins-lie.md
+++ b/.changeset/heavy-dolphins-lie.md
@@ -1,0 +1,25 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'livepeer': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Feature:** added creator ID to create asset, so users can provide either a string (which is an unverified address) or an object with a `type`. We currently only support `unverified` types, which means that passing a verified signature to verify the address is not yet possible.
+
+```tsx
+type CreateAssetCreatorId =
+  | {
+      /**
+       * The `type` of the identifier - unverified means that the value is not signed, and is an address
+       * that is blindly trusted.
+       */
+      type: 'unverified';
+      /**
+       * Developer-managed ID of the user who created the asset.
+       */
+      value: string;
+    }
+  | string;
+```

--- a/examples/_next/src/components/Asset.tsx
+++ b/examples/_next/src/components/Asset.tsx
@@ -11,6 +11,7 @@ export const Asset = () => {
     sources: videos.map((video) => ({
       file: video,
       name: video.name,
+      creatorId: '0x0000000000000000000000000000000000000000',
     })),
   });
   const {

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -182,6 +182,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
                   }
                 : undefined,
               ...(playbackPolicy ? { playbackPolicy } : {}),
+              ...(source.creatorId ? { creatorId: source.creatorId } : {}),
             },
             headers: this._defaultHeaders,
           });
@@ -210,6 +211,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
                   }
                 : undefined,
               ...(playbackPolicy ? { playbackPolicy } : {}),
+              ...(source.creatorId ? { creatorId: source.creatorId } : {}),
             },
             headers: this._defaultHeaders,
           });

--- a/packages/core/src/providers/studio/types.ts
+++ b/packages/core/src/providers/studio/types.ts
@@ -1,5 +1,6 @@
 import {
   Asset,
+  CreateAssetCreatorId,
   CreateStreamArgs,
   MultistreamTargetRef,
   Stream,
@@ -87,6 +88,8 @@ export type StudioCreateAssetArgs = {
   name: string;
   /** Storage configs for the asset */
   storage?: StudioStorageConfig;
+  /** The creator ID for the asset */
+  creatorId?: CreateAssetCreatorId;
 };
 
 export type StudioCreateAssetUrlArgs = {
@@ -98,6 +101,8 @@ export type StudioCreateAssetUrlArgs = {
   url: string;
   /** Storage configs for the asset */
   storage?: StudioStorageConfig;
+  /** The creator ID for the asset */
+  creatorId?: CreateAssetCreatorId;
 };
 
 export interface StudioCreateStreamArgs extends CreateStreamArgs {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -11,6 +11,7 @@ export type MirrorSizeArray<TArray extends ReadonlyArray<any>, TType> = {
 export type {
   Asset,
   CreateAssetArgs,
+  CreateAssetCreatorId,
   CreateAssetFileProgress,
   CreateAssetProgress,
   CreateAssetProgressBase,

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -243,6 +243,20 @@ export type StorageConfig = {
   metadataTemplate?: 'player' | 'file';
 };
 
+export type CreateAssetCreatorId =
+  | {
+      /**
+       * The `type` of the identifier - unverified means that the value is not signed, and is an address
+       * that is blindly trusted.
+       */
+      type: 'unverified';
+      /**
+       * Developer-managed ID of the user who created the asset.
+       */
+      value: string;
+    }
+  | string;
+
 export type CreateAssetSourceBase = {
   /** Name for the new asset */
   name: string;
@@ -254,6 +268,11 @@ export type CreateAssetSourceBase = {
    * Sets the playback policy for all of the assets created.
    */
   playbackPolicy?: PlaybackPolicy;
+
+  /**
+   * Sets the creator ID for the asset that is created.
+   */
+  creatorId?: CreateAssetCreatorId;
 };
 
 export type CreateAssetSourceUrl = CreateAssetSourceBase & {

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -557,6 +557,13 @@ export type Asset = {
     /** Value of the hash */
     hash?: string;
   }[];
+  creatorId?: {
+    type: 'unverified';
+    /**
+     * Developer-managed ID of the user who created the asset.
+     */
+    value: string;
+  };
   /** Detailed information about the video in the asset */
   videoSpec?: {
     /** Format of the asset, also referred to as container (e.g. MP4) */


### PR DESCRIPTION
## Description

Added creator ID to create asset, so users can provide either a string (which is an unverified address) or an object with a `type`. We currently only support `unverified` types, which means that passing a verified signature to verify the address is not yet possible.

```tsx
type CreateAssetCreatorId =
  | {
      /**
       * The `type` of the identifier - unverified means that the value is not signed, and is an address
       * that is blindly trusted.
       */
      type: 'unverified';
      /**
       * Developer-managed ID of the user who created the asset.
       */
      value: string;
    }
  | string;
```
