### PR TITLE
fix: fixed low latency

### DIFF
--- a/.changeset/blue-maps-work.md
+++ b/.changeset/blue-maps-work.md
@@ -1,0 +1,6 @@
+---
+'livepeer': patch
+'@livepeer/react': patch
+---
+
+**Fix:** changed the default WebRTC `videoTrackSelector` to be `0,1`, to select the source video/audio for the lowest latency.

--- a/packages/core-web/src/media/browser/webrtc/index.ts
+++ b/packages/core-web/src/media/browser/webrtc/index.ts
@@ -105,10 +105,7 @@ export const createNewWHEP = <TElement extends HTMLMediaElement>(
       }
 
       const sourceUrl = new URL(source);
-      sourceUrl.searchParams.set(
-        'video',
-        config?.videoTrackSelector ?? 'maxbps',
-      );
+      sourceUrl.searchParams.set('video', config?.videoTrackSelector ?? '0,1');
 
       const composedSource = sourceUrl.toString();
 


### PR DESCRIPTION
## Description

Changed the default WebRTC `videoTrackSelector` to be `0,1`, to select the source video/audio for the lowest latency.
