### PR TITLE
fix: fixed safari mobile playback for mp4

### DIFF
--- a/.changeset/lemon-pugs-sleep.md
+++ b/.changeset/lemon-pugs-sleep.md
@@ -1,0 +1,8 @@
+---
+'livepeer': patch
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'@livepeer/react': patch
+---
+
+**Fix:** fixed [Safari not emitting `canplay` event](https://github.com/video-dev/hls.js/issues/1686) with autoplay disabled, and replaced this event with `loadedmetadata` to know when the video is ready for playback.

--- a/examples/_next/src/pages/simple-player.tsx
+++ b/examples/_next/src/pages/simple-player.tsx
@@ -5,12 +5,8 @@ const Page = () => {
     <>
       {/* <div style={{ height: '110vh' }} /> */}
       <Player
-        autoPlay
-        // priority
-        muted
-        playbackId="2c98ea3a200be258"
-        loop
-        lowLatency
+        // autoPlay
+        src="https://lp-playback.com/hls/2d0c5o70uvln4zmu/1920p0.mp4"
       />
     </>
   );

--- a/examples/next/src/components/player/Player.tsx
+++ b/examples/next/src/components/player/Player.tsx
@@ -22,7 +22,6 @@ export const Player = ({ playbackId }: { playbackId: string }) => {
         objectFit="contain"
         playbackId={playbackId}
         muted
-        autoPlay
         theme={{
           colors: {
             accent: '#fff',

--- a/packages/core-react/src/hooks/playback/useAssetMetrics.test.ts
+++ b/packages/core-react/src/hooks/playback/useAssetMetrics.test.ts
@@ -21,7 +21,7 @@ describe('useAssetMetrics', () => {
         "metrics": [
           {
             "id": "d8e8c2v2dqal5je6",
-            "startViews": 3,
+            "startViews": 4,
           },
         ],
         "type": "ViewsMetrics",

--- a/packages/core-web/src/media/browser/controls/controller.ts
+++ b/packages/core-web/src/media/browser/controls/controller.ts
@@ -98,7 +98,7 @@ export const addEventListeners = <TElement extends HTMLMediaElement>(
     (element) => {
       destroy?.();
 
-      const onCanPlay = () => store.getState().onCanPlay();
+      const onLoadedMetadata = () => store.getState().onCanPlay();
 
       const onPlay = () => {
         store.getState().onPlay();
@@ -237,7 +237,7 @@ export const addEventListeners = <TElement extends HTMLMediaElement>(
       if (element) {
         element.addEventListener('volumechange', onVolumeChange);
 
-        element.addEventListener('canplay', onCanPlay);
+        element.addEventListener('loadedmetadata', onLoadedMetadata);
         element.addEventListener('play', onPlay);
         element.addEventListener('pause', onPause);
         element.addEventListener('durationchange', onDurationChange);
@@ -307,7 +307,7 @@ export const addEventListeners = <TElement extends HTMLMediaElement>(
         removeExitPictureInPictureListener?.();
 
         element?.removeEventListener?.('volumechange', onVolumeChange);
-        element?.removeEventListener?.('canplay', onCanPlay);
+        element?.removeEventListener?.('loadedmetadata', onLoadedMetadata);
         element?.removeEventListener?.('play', onPlay);
         element?.removeEventListener?.('pause', onPause);
         element?.removeEventListener?.('durationchange', onDurationChange);

--- a/packages/core/src/actions/playback/getAssetMetrics.test.ts
+++ b/packages/core/src/actions/playback/getAssetMetrics.test.ts
@@ -18,7 +18,7 @@ describe('getAssetMetrics', () => {
         "metrics": [
           {
             "id": "373d7a8kibjpsi0d",
-            "startViews": 26,
+            "startViews": 27,
           },
         ],
         "type": "ViewsMetrics",


### PR DESCRIPTION
## Description

Fixed [Safari not emitting `canplay` event](https://github.com/video-dev/hls.js/issues/1686) with autoplay disabled, and replaced this event with `loadedmetadata` to know when the video is ready for playback.
