### PR TITLE
Add assetId to progress object

### DIFF
--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -150,6 +150,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
     let progress = sources.map((source) => ({
       name: source.name,
       progress: 0,
+      assetId: null,
       phase: (source as CreateAssetSourceUrl)?.url ? 'waiting' : 'uploading',
     })) as CreateAssetProgress<TSource>;
 
@@ -250,6 +251,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
 
                   const status: CreateAssetFileProgress = {
                     name: source.name,
+                    assetId,
                     progress: progressPercent,
                     phase: 'uploading',
                   };
@@ -329,6 +331,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
             if (typeof asset.status?.phase !== 'undefined') {
               const status: CreateAssetUrlProgress = {
                 name: asset.name,
+                assetId: asset.id,
                 progress: asset.status.progress ?? 0,
                 phase: asset.status.phase,
               };
@@ -358,6 +361,7 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
 
         const status: CreateAssetUrlProgress = {
           name: asset.name,
+          assetId: asset.id,
           progress: 1,
           phase: asset.status.phase,
         };

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -211,18 +211,18 @@ export type CreateAssetProgressBase = {
    * This will reset to zero upon beginning the next phase.
    */
   progress: number;
+  /** ID for the asset, from the backend */
+  assetId: string | null;
 };
 
 export type CreateAssetFileProgress = CreateAssetProgressBase & {
   /** Phase of the asset */
   phase: 'uploading' | 'waiting' | 'processing' | 'ready' | 'failed';
-  assetId: string | null;
 };
 
 export type CreateAssetUrlProgress = CreateAssetProgressBase & {
   /** Phase of the asset */
   phase: 'waiting' | 'processing' | 'ready' | 'failed';
-  assetId: string | null;
 };
 
 export type CreateAssetProgress<TSource extends CreateAssetSourceType> = {

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -216,11 +216,13 @@ export type CreateAssetProgressBase = {
 export type CreateAssetFileProgress = CreateAssetProgressBase & {
   /** Phase of the asset */
   phase: 'uploading' | 'waiting' | 'processing' | 'ready' | 'failed';
+  assetId: string;
 };
 
 export type CreateAssetUrlProgress = CreateAssetProgressBase & {
   /** Phase of the asset */
   phase: 'waiting' | 'processing' | 'ready' | 'failed';
+  assetId: string;
 };
 
 export type CreateAssetProgress<TSource extends CreateAssetSourceType> = {

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -216,13 +216,13 @@ export type CreateAssetProgressBase = {
 export type CreateAssetFileProgress = CreateAssetProgressBase & {
   /** Phase of the asset */
   phase: 'uploading' | 'waiting' | 'processing' | 'ready' | 'failed';
-  assetId: string;
+  assetId: string | null;
 };
 
 export type CreateAssetUrlProgress = CreateAssetProgressBase & {
   /** Phase of the asset */
   phase: 'waiting' | 'processing' | 'ready' | 'failed';
-  assetId: string;
+  assetId: string | null;
 };
 
 export type CreateAssetProgress<TSource extends CreateAssetSourceType> = {


### PR DESCRIPTION
## Description

As a developer, I want to be able to catch the `assetId` as soon as possible (latest after the upload is done) so I can save it for later use in case of user closes or reloads the browser window.

## Additional Information

- [x] I read the [contributing docs](/livepeer/livepeer.js/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
