### PR TITLE
Added version to websocket logs

### DIFF
--- a/.changeset/perfect-bananas-pull.md
+++ b/.changeset/perfect-bananas-pull.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'livepeer': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+'@livepeer/core-react': patch
+---
+
+**Chore:** added version identifiers to the playback websocket to help narrow issues related to specific livepeer.js releases.

--- a/generate-version.ts
+++ b/generate-version.ts
@@ -13,7 +13,7 @@ import {
 import fs from 'fs';
 
 fs.writeFileSync(
-  `./packages/core/src/providers/version.ts`,
+  `./packages/core/src/version.ts`,
   `export const core = \`${coreName}@${coreVersion}\`;
 export const react = \`${reactName}@${reactVersion}\`;
 export const reactNative = \`${reactNativeName}@${reactNativeVersion}\`;

--- a/generate-version.ts
+++ b/generate-version.ts
@@ -14,8 +14,14 @@ import fs from 'fs';
 
 fs.writeFileSync(
   `./packages/core/src/version.ts`,
-  `export const core = \`${coreName}@${coreVersion}\`;
-export const react = \`${reactName}@${reactVersion}\`;
-export const reactNative = \`${reactNativeName}@${reactNativeVersion}\`;
+  `const core = \`${coreName}@${coreVersion}\`;
+const react = \`${reactName}@${reactVersion}\`;
+const reactNative = \`${reactNativeName}@${reactNativeVersion}\`;
+
+export const version = {
+  core,
+  react,
+  reactNative,
+} as const;
 `,
 );

--- a/packages/core-web/src/index.test.ts
+++ b/packages/core-web/src/index.test.ts
@@ -39,6 +39,7 @@ it('should expose correct exports', () => {
       "pick",
       "updateAsset",
       "updateStream",
+      "version",
       "watchLivepeerProvider",
     ]
   `);

--- a/packages/core-web/src/media/browser/controls/device.ts
+++ b/packages/core-web/src/media/browser/controls/device.ts
@@ -2,7 +2,8 @@ import { DeviceInformation } from '@livepeer/core';
 
 import { isAndroid, isIos, isMobile } from '../utils';
 
-export const getDeviceInfo = (): DeviceInformation => ({
+export const getDeviceInfo = (version: string): DeviceInformation => ({
+  version,
   isAndroid: isAndroid(),
   isIos: isIos(),
   isMobile: isMobile(),

--- a/packages/core-web/src/media/browser/metrics.test.ts
+++ b/packages/core-web/src/media/browser/metrics.test.ts
@@ -22,8 +22,10 @@ describe('addMediaMetrics', () => {
 
       expect(metricsSnapshot?.current?.userAgent).toBeTruthy();
 
-      if (metricsSnapshot?.current?.userAgent)
+      if (metricsSnapshot?.current?.userAgent) {
         metricsSnapshot.current.userAgent = 'UA';
+        metricsSnapshot.current.player = 'hls-1';
+      }
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
         {
@@ -35,7 +37,7 @@ describe('addMediaMetrics', () => {
           "nWaiting": 0,
           "pageUrl": "http://localhost:3000/",
           "playbackScore": null,
-          "player": "unknown",
+          "player": "hls-1",
           "playerHeight": null,
           "playerWidth": null,
           "preloadTime": 0,
@@ -64,35 +66,37 @@ describe('addMediaMetrics', () => {
 
       expect(metricsSnapshot?.current?.userAgent).toBeTruthy();
 
-      if (metricsSnapshot?.current?.userAgent)
+      if (metricsSnapshot?.current?.userAgent) {
         metricsSnapshot.current.userAgent = 'UA';
+        metricsSnapshot.current.player = 'hls-1';
+      }
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-      {
-        "autoplay": "standard",
-        "duration": 0,
-        "firstPlayback": 0,
-        "nError": 0,
-        "nStalled": 0,
-        "nWaiting": 0,
-        "pageUrl": "http://localhost:3000/",
-        "playbackScore": null,
-        "player": "unknown",
-        "playerHeight": null,
-        "playerWidth": null,
-        "preloadTime": 0,
-        "sourceType": "unknown",
-        "sourceUrl": null,
-        "timeStalled": 0,
-        "timeUnpaused": 0,
-        "timeWaiting": 0,
-        "ttff": 0,
-        "uid": "",
-        "userAgent": "UA",
-        "videoHeight": null,
-        "videoWidth": null,
-      }
-    `);
+        {
+          "autoplay": "standard",
+          "duration": 0,
+          "firstPlayback": 0,
+          "nError": 0,
+          "nStalled": 0,
+          "nWaiting": 0,
+          "pageUrl": "http://localhost:3000/",
+          "playbackScore": null,
+          "player": "hls-1",
+          "playerHeight": null,
+          "playerWidth": null,
+          "preloadTime": 0,
+          "sourceType": "unknown",
+          "sourceUrl": null,
+          "timeStalled": 0,
+          "timeUnpaused": 0,
+          "timeWaiting": 0,
+          "ttff": 0,
+          "uid": "",
+          "userAgent": "UA",
+          "videoHeight": null,
+          "videoWidth": null,
+        }
+      `);
     });
 
     it('should update time waiting and waiting count', async () => {
@@ -106,35 +110,37 @@ describe('addMediaMetrics', () => {
 
       expect(metricsSnapshot?.current?.userAgent).toBeTruthy();
 
-      if (metricsSnapshot?.current?.userAgent)
+      if (metricsSnapshot?.current?.userAgent) {
         metricsSnapshot.current.userAgent = 'UA';
+        metricsSnapshot.current.player = 'hls-1';
+      }
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-          {
-            "autoplay": "standard",
-            "duration": 0,
-            "firstPlayback": 0,
-            "nError": 0,
-            "nStalled": 0,
-            "nWaiting": 0,
-            "pageUrl": "http://localhost:3000/",
-            "playbackScore": null,
-            "player": "unknown",
-            "playerHeight": null,
-            "playerWidth": null,
-            "preloadTime": 0,
-            "sourceType": "unknown",
-            "sourceUrl": null,
-            "timeStalled": 0,
-            "timeUnpaused": 0,
-            "timeWaiting": 0,
-            "ttff": 0,
-            "uid": "",
-            "userAgent": "UA",
-            "videoHeight": null,
-            "videoWidth": null,
-          }
-        `);
+        {
+          "autoplay": "standard",
+          "duration": 0,
+          "firstPlayback": 0,
+          "nError": 0,
+          "nStalled": 0,
+          "nWaiting": 0,
+          "pageUrl": "http://localhost:3000/",
+          "playbackScore": null,
+          "player": "hls-1",
+          "playerHeight": null,
+          "playerWidth": null,
+          "preloadTime": 0,
+          "sourceType": "unknown",
+          "sourceUrl": null,
+          "timeStalled": 0,
+          "timeUnpaused": 0,
+          "timeWaiting": 0,
+          "ttff": 0,
+          "uid": "",
+          "userAgent": "UA",
+          "videoHeight": null,
+          "videoWidth": null,
+        }
+      `);
     });
 
     it('should update time stalled and stalled count', async () => {
@@ -150,35 +156,37 @@ describe('addMediaMetrics', () => {
 
       expect(metricsSnapshot?.current?.userAgent).toBeTruthy();
 
-      if (metricsSnapshot?.current?.userAgent)
+      if (metricsSnapshot?.current?.userAgent) {
         metricsSnapshot.current.userAgent = 'UA';
+        metricsSnapshot.current.player = 'hls-1';
+      }
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-                  {
-                    "autoplay": "standard",
-                    "duration": 0,
-                    "firstPlayback": 0,
-                    "nError": 0,
-                    "nStalled": 0,
-                    "nWaiting": 0,
-                    "pageUrl": "http://localhost:3000/",
-                    "playbackScore": null,
-                    "player": "unknown",
-                    "playerHeight": null,
-                    "playerWidth": null,
-                    "preloadTime": 0,
-                    "sourceType": "unknown",
-                    "sourceUrl": null,
-                    "timeStalled": 0,
-                    "timeUnpaused": 0,
-                    "timeWaiting": 0,
-                    "ttff": 0,
-                    "uid": "",
-                    "userAgent": "UA",
-                    "videoHeight": null,
-                    "videoWidth": null,
-                  }
-                `);
+        {
+          "autoplay": "standard",
+          "duration": 0,
+          "firstPlayback": 0,
+          "nError": 0,
+          "nStalled": 0,
+          "nWaiting": 0,
+          "pageUrl": "http://localhost:3000/",
+          "playbackScore": null,
+          "player": "hls-1",
+          "playerHeight": null,
+          "playerWidth": null,
+          "preloadTime": 0,
+          "sourceType": "unknown",
+          "sourceUrl": null,
+          "timeStalled": 0,
+          "timeUnpaused": 0,
+          "timeWaiting": 0,
+          "ttff": 0,
+          "uid": "",
+          "userAgent": "UA",
+          "videoHeight": null,
+          "videoWidth": null,
+        }
+      `);
     });
   });
 
@@ -195,31 +203,35 @@ describe('addMediaMetrics', () => {
 
     expect(metricsSnapshot?.current?.userAgent).toBeTruthy();
 
+    if (metricsSnapshot?.current?.player) {
+      metricsSnapshot.current.player = 'hls-1';
+    }
+
     expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-                      {
-                        "autoplay": "standard",
-                        "duration": 0,
-                        "firstPlayback": 0,
-                        "nError": 0,
-                        "nStalled": 0,
-                        "nWaiting": 0,
-                        "pageUrl": "http://localhost:3000/",
-                        "playbackScore": null,
-                        "player": "unknown",
-                        "playerHeight": null,
-                        "playerWidth": null,
-                        "preloadTime": 0,
-                        "sourceType": "unknown",
-                        "sourceUrl": null,
-                        "timeStalled": 0,
-                        "timeUnpaused": 0,
-                        "timeWaiting": 0,
-                        "ttff": 0,
-                        "uid": "",
-                        "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36",
-                        "videoHeight": null,
-                        "videoWidth": null,
-                      }
-                    `);
+      {
+        "autoplay": "standard",
+        "duration": 0,
+        "firstPlayback": 0,
+        "nError": 0,
+        "nStalled": 0,
+        "nWaiting": 0,
+        "pageUrl": "http://localhost:3000/",
+        "playbackScore": null,
+        "player": "hls-1",
+        "playerHeight": null,
+        "playerWidth": null,
+        "preloadTime": 0,
+        "sourceType": "unknown",
+        "sourceUrl": null,
+        "timeStalled": 0,
+        "timeUnpaused": 0,
+        "timeWaiting": 0,
+        "ttff": 0,
+        "uid": "",
+        "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36",
+        "videoHeight": null,
+        "videoWidth": null,
+      }
+    `);
   });
 });

--- a/packages/core-web/src/media/browser/metrics.ts
+++ b/packages/core-web/src/media/browser/metrics.ts
@@ -3,6 +3,7 @@ import {
   MediaMetrics,
   PlayerPropsOptions,
   createStorage,
+  version,
 } from '@livepeer/core';
 import {
   addMediaMetricsToStore,
@@ -29,7 +30,7 @@ export function addMediaMetrics<TElement extends HTMLMediaElement>(
 ): MediaMetrics<TElement> {
   const store = createControllerStore<TElement>({
     element: element ?? undefined,
-    device: getDeviceInfo(),
+    device: getDeviceInfo(version.core),
     storage: createStorage(
       typeof window !== 'undefined'
         ? {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -38,6 +38,7 @@ it('should expose correct exports', () => {
       "pick",
       "updateAsset",
       "updateStream",
+      "version",
       "watchLivepeerProvider",
     ]
   `);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,3 +97,4 @@ export {
   omit,
   pick,
 } from './utils';
+export * as version from './version';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,4 +97,4 @@ export {
   omit,
   pick,
 } from './utils';
-export * as version from './version';
+export { version } from './version';

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -37,6 +37,7 @@ const getPlaybackIdFromSourceUrl = (sourceUrl: string) => {
 };
 
 export type DeviceInformation = {
+  version: string;
   isMobile: boolean;
   isIos: boolean;
   isAndroid: boolean;

--- a/packages/core/src/media/metrics/metrics.ts
+++ b/packages/core/src/media/metrics/metrics.ts
@@ -25,7 +25,7 @@ type RawMetrics = {
 
   playbackScore: number | null;
 
-  player: 'audio' | 'hls' | 'video' | 'webrtc' | 'unknown';
+  player: `${'audio' | 'hls' | 'video' | 'webrtc' | 'unknown'}-${string}`;
 
   sourceType: MimeType | 'unknown';
 
@@ -206,6 +206,9 @@ export class MetricsStatus<TElement> {
         : windowHref
       : windowHref;
 
+    const playerPrefix = currentState?.src?.type ?? 'unknown';
+    const version = currentState?.device.version ?? 'unknown';
+
     this.currentMetrics = {
       autoplay:
         currentState.priority && currentState.autoplay
@@ -222,7 +225,7 @@ export class MetricsStatus<TElement> {
       nWaiting: 0,
       pageUrl,
       playbackScore: null,
-      player: currentState?.src?.type ?? 'unknown',
+      player: `${playerPrefix}-${version}`,
       sourceType: currentState?.src?.mime ?? 'unknown',
       sourceUrl: currentState?.src?.src ?? null,
       playerHeight: null,
@@ -261,7 +264,10 @@ export class MetricsStatus<TElement> {
       }
 
       if (state.src?.src !== prevState.src?.src) {
-        this.currentMetrics.player = state.src?.type ?? 'unknown';
+        const playerPrefix = currentState?.src?.type ?? 'unknown';
+        const version = currentState?.device.version ?? 'unknown';
+
+        this.currentMetrics.player = `${playerPrefix}-${version}`;
         this.currentMetrics.sourceType = state.src?.mime ?? 'unknown';
         this.currentMetrics.sourceUrl = state.src?.src ?? null;
       }

--- a/packages/core/src/providers/base.ts
+++ b/packages/core/src/providers/base.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch';
 
-import * as versions from './version';
+import { version } from '..';
 import { HttpError } from '../errors';
 
 import {
@@ -51,9 +51,9 @@ export abstract class BaseLivepeerProvider implements LivepeerProvider {
       ...options,
       headers: {
         ...options?.headers,
-        'x-core-sdk-version': versions.core,
-        'x-react-sdk-version': versions.react,
-        'x-react-native-sdk-version': versions.reactNative,
+        'x-core-sdk-version': version.core,
+        'x-react-sdk-version': version.react,
+        'x-react-native-sdk-version': version.reactNative,
       },
     });
 
@@ -79,9 +79,9 @@ export abstract class BaseLivepeerProvider implements LivepeerProvider {
       headers: {
         ...(options?.json ? { 'content-type': 'application/json' } : {}),
         ...options?.headers,
-        'x-core-sdk-version': versions.core,
-        'x-react-sdk-version': versions.react,
-        'x-react-native-sdk-version': versions.reactNative,
+        'x-core-sdk-version': version.core,
+        'x-react-sdk-version': version.react,
+        'x-react-native-sdk-version': version.reactNative,
       },
     });
 
@@ -107,9 +107,9 @@ export abstract class BaseLivepeerProvider implements LivepeerProvider {
       headers: {
         ...(options?.json ? { 'content-type': 'application/json' } : {}),
         ...options?.headers,
-        'x-core-sdk-version': versions.core,
-        'x-react-sdk-version': versions.react,
-        'x-react-native-sdk-version': versions.reactNative,
+        'x-core-sdk-version': version.core,
+        'x-react-sdk-version': version.react,
+        'x-react-native-sdk-version': version.reactNative,
       },
     });
 

--- a/packages/core/src/providers/version.ts
+++ b/packages/core/src/providers/version.ts
@@ -1,3 +1,0 @@
-export const core = `@livepeer/core@1.5.3`;
-export const react = `@livepeer/react@2.5.3`;
-export const reactNative = `@livepeer/react-native@1.5.3`;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,0 +1,3 @@
+export const core = `@livepeer/core@1.5.5`;
+export const react = `@livepeer/react@2.5.5`;
+export const reactNative = `@livepeer/react-native@1.5.4`;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,3 +1,9 @@
-export const core = `@livepeer/core@1.5.5`;
-export const react = `@livepeer/react@2.5.5`;
-export const reactNative = `@livepeer/react-native@1.5.4`;
+const core = `@livepeer/core@1.5.5`;
+const react = `@livepeer/react@2.5.5`;
+const reactNative = `@livepeer/react-native@1.5.4`;
+
+export const version = {
+  core,
+  react,
+  reactNative,
+} as const;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,9 +1,3 @@
-const core = `@livepeer/core@1.5.5`;
-const react = `@livepeer/react@2.5.5`;
-const reactNative = `@livepeer/react-native@1.5.4`;
-
-export const version = {
-  core,
-  react,
-  reactNative,
-} as const;
+export const core = `@livepeer/core@1.5.5`;
+export const react = `@livepeer/react@2.5.5`;
+export const reactNative = `@livepeer/react-native@1.5.4`;

--- a/packages/react-native/src/components/media/state/controls.ts
+++ b/packages/react-native/src/components/media/state/controls.ts
@@ -4,6 +4,7 @@ import {
   Storage,
   createControllerStore,
   createStorage,
+  version,
 } from '@livepeer/core-react';
 import { Platform } from 'react-native';
 import { StoreApi } from 'zustand';
@@ -24,6 +25,7 @@ export const createNativeControllerStore = <TElement extends MediaElement>({
   return createControllerStore<TElement>({
     element: undefined,
     device: {
+      version: version.reactNative,
       isMobile: true,
       isAndroid: Platform?.OS === 'android',
       isIos: Platform?.OS === 'ios',

--- a/packages/react/src/context/MediaControllerContext.tsx
+++ b/packages/react/src/context/MediaControllerContext.tsx
@@ -1,4 +1,4 @@
-import { createStorage } from 'livepeer';
+import { createStorage, version } from 'livepeer';
 import { MediaControllerStore, createControllerStore } from 'livepeer/media';
 import { getDeviceInfo } from 'livepeer/media/browser';
 import * as React from 'react';
@@ -8,7 +8,7 @@ export const MediaControllerContext = React.createContext<
 >(
   createControllerStore<HTMLMediaElement>({
     element: undefined,
-    device: getDeviceInfo(),
+    device: getDeviceInfo(version.react),
     storage: createStorage({}),
     playerProps: {},
     opts: {},

--- a/packages/react/src/context/MediaControllerProvider.tsx
+++ b/packages/react/src/context/MediaControllerProvider.tsx
@@ -1,4 +1,5 @@
 import { useClient } from '@livepeer/core-react/context';
+import { version } from 'livepeer';
 import {
   ControlsOptions,
   PlayerPropsOptions,
@@ -41,7 +42,7 @@ const useMediaControllerStore = <TElement extends HTMLMediaElement>(
   const store = React.useMemo(
     () =>
       createControllerStore<TElement>({
-        device: getDeviceInfo(),
+        device: getDeviceInfo(version.react),
         storage: client.storage,
         opts: opts ?? {},
         playerProps,

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -84,6 +84,7 @@ it('should expose correct exports', () => {
       "useTheme",
       "useUpdateAsset",
       "useUpdateStream",
+      "version",
       "watchLivepeerProvider",
     ]
   `);


### PR DESCRIPTION
## Description

Added version identifiers to the playback websocket to help narrow issues related to specific livepeer.js releases.

Fixes https://linear.app/livepeer/issue/DX-237/add-livepeerjs-version-to-player-identifier-in-playback-logs