### PR TITLE
changes to support webrtc in the box

### DIFF
--- a/examples/_react-native/package.json
+++ b/examples/_react-native/package.json
@@ -8,7 +8,7 @@
     "dev:ios": "react-native run-ios",
     "install:pod": "cd ios/ && pod install",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "postinstall": "pnpm install:pod"
+    "postinstall": "pnpm install:pod || echo 'pod installation failed, skipping'"
   },
   "dependencies": {
     "@livepeer/react-native": "^1.8.1",

--- a/examples/next-13/app/providers.tsx
+++ b/examples/next-13/app/providers.tsx
@@ -9,6 +9,16 @@ import {
 } from '@livepeer/react';
 import { useMemo } from 'react';
 
+function fromStorage(key: string): string | null {
+  let apiOverride: string | null = null;
+  try {
+    apiOverride = localStorage.getItem(key);
+  } catch (e) {
+    // No problem. Default behavior.
+  }
+  return apiOverride;
+}
+
 export const Providers = ({ children }: React.PropsWithChildren) => {
   const livepeerClient = useMemo(
     () =>
@@ -17,11 +27,16 @@ export const Providers = ({ children }: React.PropsWithChildren) => {
           storage: noopStorage,
         }),
         provider: studioProvider({
-          apiKey: process.env.NEXT_PUBLIC_STUDIO_API_KEY ?? '',
+          apiKey:
+            fromStorage('STUDIO_API_KEY') ??
+            process.env.NEXT_PUBLIC_STUDIO_API_KEY ??
+            '',
           baseUrl:
+            fromStorage('STUDIO_BASE_URL') ??
             process.env.NEXT_PUBLIC_STUDIO_BASE_URL ??
             'https://livepeer.studio/api',
           webrtcIngestBaseUrl:
+            fromStorage('WEBRTC_INGEST_BASE_URL') ??
             process.env.NEXT_PUBLIC_WEBRTC_INGEST_BASE_URL ??
             'https://webrtc.livepeer.studio/webrtc',
           ...{ origin: `https://lvpr.tv` },

--- a/examples/next-13/next.config.js
+++ b/examples/next-13/next.config.js
@@ -1,6 +1,6 @@
 const { withSentryConfig } = require('@sentry/nextjs');
 
-const disableSentry = process.env.DIABLE_SENTRY === 'true';
+const disableSentry = process.env.DISABLE_SENTRY === 'true';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/examples/next-13/next.config.js
+++ b/examples/next-13/next.config.js
@@ -1,5 +1,7 @@
 const { withSentryConfig } = require('@sentry/nextjs');
 
+const disableSentry = process.env.DIABLE_SENTRY === 'true';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
@@ -15,6 +17,13 @@ const nextConfig = {
     // for more information.
     hideSourceMaps: true,
   },
+
+  transpilePackages: [
+    '@livepeer/core-react',
+    '@livepeer/core',
+    '@livepeer/react-native',
+    '@livepeer/react',
+  ],
 };
 
 const sentryWebpackPluginOptions = {
@@ -31,4 +40,8 @@ const sentryWebpackPluginOptions = {
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+if (disableSentry) {
+  module.exports = nextConfig;
+} else {
+  module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+}

--- a/packages/core-web/src/media/browser/webrtc/shared.ts
+++ b/packages/core-web/src/media/browser/webrtc/shared.ts
@@ -41,13 +41,16 @@ export function createPeerConnection(
     window?.webkitRTCPeerConnection ||
     window?.mozRTCPeerConnection;
 
+  // strip non-standard port number if present
+  const hostNoPort = host?.split(':')[0];
+
   const iceServers = host
     ? [
         {
-          urls: `stun:${host}`,
+          urls: `stun:${hostNoPort}`,
         },
         {
-          urls: `turn:${host}`,
+          urls: `turn:${hostNoPort}`,
           username: 'livepeer',
           credential: 'livepeer',
         },


### PR DESCRIPTION
The actual fix is https://github.com/livepeer/livepeer.js/commit/26d56d083dba2eb9acbfe675b4685117c99a93f5, which allows us to look for a TURN server on the default port instead of `localhost:8888` when that gets passed in.

https://github.com/livepeer/livepeer.js/commit/b5f7804a33dc0d8dbdacd8eacea04908f4fcd838 was needed to point the player to the dev server instead of prod.

https://github.com/livepeer/livepeer.js/commit/c22f3cc79b9048e4cb154bc12871594ab3f25188 was needed for `pnpm install` to work on a non-Mac environment

https://github.com/livepeer/livepeer.js/commit/8d146b7bbe15de058fea16fcf2bf90d72db80f65 seemed to happen automatically as I was just running the various `pnpm` commands and I'm not 100% sure what's up with that.
