### PR TITLE
feat: added better props for player error states

### DIFF
--- a/.changeset/witty-mirrors-jog.md
+++ b/.changeset/witty-mirrors-jog.md
@@ -1,0 +1,21 @@
+---
+'@livepeer/core-react': patch
+'@livepeer/react': patch
+'@livepeer/core': patch
+'livepeer': patch
+'@livepeer/react-native': patch
+---
+
+**Feature:** added custom components to render in place of the default error components, for when a stream is offline: `streamOfflineErrorComponent`, when an access control error occurs (like an invalid JWT is passed): `accessControlErrorComponent`, and when playback fails another unknown error: `playbackFailedErrorComponent`.
+
+Also added a callback for when these errors occur: `onPlaybackError`. This can be used like:
+
+```tsx
+onPlaybackError={(e) => {
+  if (e === null) {
+    doSomethingWithErrorResolved();
+  } else if (e?.type === 'offline') {
+    doSomethingWithOfflineError();
+  }
+}}
+```

--- a/packages/core-react/src/components/index.ts
+++ b/packages/core-react/src/components/index.ts
@@ -13,7 +13,7 @@ export {
   type BroadcastProps,
   type ContainerProps,
   type ControlsContainerProps,
-  type ControlsError,
+  type PlaybackError,
   type FullscreenButtonProps,
   type InternalPlayerProps,
   type ObjectFit,

--- a/packages/core-react/src/components/media/broadcast/useBroadcast.tsx
+++ b/packages/core-react/src/components/media/broadcast/useBroadcast.tsx
@@ -10,7 +10,7 @@ import { AspectRatio, ThemeConfig } from '@livepeer/core/media';
 import * as React from 'react';
 
 import { useLivepeerProvider } from '../../../hooks';
-import { ControlsError, ObjectFit } from '../shared';
+import { ObjectFit, PlaybackError } from '../shared';
 
 export type BroadcastProps<TElement, TMediaStream, TSlice> = {
   /** The stream key for the broadcast. This is required. */
@@ -93,11 +93,11 @@ export const useBroadcast = <TElement, TMediaStream, TSlice>({
   const [mediaElement, setMediaElement] = React.useState<TElement | null>(null);
 
   const [broadcastError, setBroadcastError] =
-    React.useState<ControlsError | null>(null);
+    React.useState<PlaybackError | null>(null);
 
   const onBroadcastError = React.useCallback(
     (error: Error | null) => {
-      const newError: ControlsError | null = error
+      const newError: PlaybackError | null = error
         ? {
             type: isAccessControlError(error)
               ? 'access-control'

--- a/packages/core-react/src/components/media/controls/useControlsContainer.tsx
+++ b/packages/core-react/src/components/media/controls/useControlsContainer.tsx
@@ -1,15 +1,19 @@
 import { MediaControllerState } from '@livepeer/core';
 import * as React from 'react';
 
-import { ControlsError } from '../shared';
+import { PlaybackError } from '../shared';
 
 export type ControlsContainerProps = {
   loadingText?: string | null;
   showLoadingSpinner?: boolean;
   hidePosterOnPlayed?: boolean;
   poster?: React.ReactNode;
-  error?: ControlsError | null;
+  error?: PlaybackError | null;
   isBroadcast?: boolean;
+
+  playbackFailedErrorComponent?: React.ReactNode;
+  streamOfflineErrorComponent?: React.ReactNode;
+  accessControlErrorComponent?: React.ReactNode;
 
   top?: React.ReactNode;
   middle?: React.ReactNode;

--- a/packages/core-react/src/components/media/index.ts
+++ b/packages/core-react/src/components/media/index.ts
@@ -20,4 +20,4 @@ export {
 export type { AudioPlayerProps, VideoPlayerProps } from './player/players';
 export { usePlayer } from './player/usePlayer';
 export type { InternalPlayerProps, PlayerProps } from './player/usePlayer';
-export type { ControlsError, ObjectFit } from './shared';
+export type { PlaybackError, ObjectFit } from './shared';

--- a/packages/core-react/src/components/media/player/players.tsx
+++ b/packages/core-react/src/components/media/player/players.tsx
@@ -8,7 +8,7 @@ import {
 } from '@livepeer/core';
 
 import { PlayerProps } from './usePlayer';
-import { ControlsError, ObjectFit } from '../shared';
+import { ObjectFit, PlaybackError } from '../shared';
 
 export type VideoPlayerProps<
   TElement,
@@ -51,7 +51,7 @@ export type VideoPlayerProps<
     TSlice
   >['playbackStatusSelector'];
 
-  playbackError: ControlsError | null;
+  playbackError: PlaybackError | null;
   onPlaybackError: (error: Error | null) => void;
 };
 

--- a/packages/core-react/src/components/media/player/usePlayer.tsx
+++ b/packages/core-react/src/components/media/player/usePlayer.tsx
@@ -245,14 +245,14 @@ export const usePlayer = <
           }
         : null;
 
-      onPlaybackErrorProp?.(newPlaybackError);
-
       setPlaybackError(newPlaybackError);
 
       try {
         if (newPlaybackError) {
           console.log(newPlaybackError);
         }
+
+        onPlaybackErrorProp?.(newPlaybackError);
 
         if (!error) {
           onStreamStatusChange?.(true);
@@ -264,13 +264,13 @@ export const usePlayer = <
           onError?.(new Error(newPlaybackError.message));
         }
       } catch (e) {
-        //
+        console.error(e);
       }
 
       return newPlaybackError;
     },
 
-    [onAccessControlError, onStreamStatusChange, onError],
+    [onAccessControlError, onStreamStatusChange, onError, onPlaybackErrorProp],
   );
 
   React.useEffect(() => {

--- a/packages/core-react/src/components/media/shared.ts
+++ b/packages/core-react/src/components/media/shared.ts
@@ -1,6 +1,6 @@
 export type ObjectFit = 'cover' | 'contain';
 
-export type ControlsError = {
+export type PlaybackError = {
   type: 'offline' | 'access-control' | 'fallback' | 'unknown';
   message: string;
 };

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,6 +1,6 @@
-const core = `@livepeer/core@1.8.3`;
-const react = `@livepeer/react@2.8.3`;
-const reactNative = `@livepeer/react-native@1.8.2`;
+const core = `@livepeer/core@1.8.5`;
+const react = `@livepeer/react@2.8.5`;
+const reactNative = `@livepeer/react-native@1.8.4`;
 
 export const version = {
   core,

--- a/packages/react/src/components/media/controls/ControlsContainer.tsx
+++ b/packages/react/src/components/media/controls/ControlsContainer.tsx
@@ -45,6 +45,9 @@ export const ControlsContainer: React.FC<ControlsContainerProps> = (props) => {
     loadingText,
     error,
     children,
+    playbackFailedErrorComponent,
+    streamOfflineErrorComponent,
+    accessControlErrorComponent,
   } = props;
 
   const {
@@ -110,9 +113,19 @@ export const ControlsContainer: React.FC<ControlsContainerProps> = (props) => {
           onMouseUp={containerProps.onPress}
         >
           {error?.type === 'access-control' ? (
-            <PrivateStreamError />
+            accessControlErrorComponent ? (
+              accessControlErrorComponent
+            ) : (
+              <PrivateStreamError />
+            )
           ) : error?.type === 'offline' ? (
-            <OfflineStreamError isBroadcast={isBroadcast} />
+            streamOfflineErrorComponent ? (
+              streamOfflineErrorComponent
+            ) : (
+              <OfflineStreamError isBroadcast={isBroadcast} />
+            )
+          ) : playbackFailedErrorComponent ? (
+            playbackFailedErrorComponent
           ) : (
             <GenericError isBroadcast={isBroadcast} />
           )}


### PR DESCRIPTION
## Description

Added custom components to render in place of the default error components, for when a stream is offline: `streamOfflineErrorComponent`, when an access control error occurs (like an invalid JWT is passed): `accessControlErrorComponent`, and when playback fails another unknown error: `playbackFailedErrorComponent`.

Also added a callback for when these errors occur: `onPlaybackError`. This can be used like:

```tsx
onPlaybackError={(e) => {
  if (e === null) {
    doSomethingWithErrorResolved();
  } else if (e?.type === 'offline') {
    doSomethingWithOfflineError();
  }
}}
```
