### PR TITLE
breaking: removed playback URL from stream

### DIFF
--- a/.changeset/three-wolves-walk.md
+++ b/.changeset/three-wolves-walk.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': minor
+'@livepeer/core-react': minor
+'livepeer': minor
+'@livepeer/react': minor
+'@livepeer/react-native': minor
+---
+
+**Breaking:** removed `playbackUrl` from stream responses. Developers should migrate to using `playbackId` to query stream playback URLs.

--- a/packages/core-react/src/hooks/stream/useStream.test.ts
+++ b/packages/core-react/src/hooks/stream/useStream.test.ts
@@ -14,8 +14,10 @@ describe('useStream', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBeTruthy());
 
-    expect(result?.current?.data?.playbackUrl).toMatchInlineSnapshot(
-      '"https://livepeercdn.com/hls/d7aer9qx8act4lfd/index.m3u8"',
+    expect((result?.current?.data as any)?.['playbackUrl']).toBeUndefined();
+
+    expect(result?.current?.data?.playbackId).toMatchInlineSnapshot(
+      '"d7aer9qx8act4lfd"',
     );
   });
 

--- a/packages/core-web/src/media/browser/metrics.test.ts
+++ b/packages/core-web/src/media/browser/metrics.test.ts
@@ -3,9 +3,6 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { addMediaMetrics } from './metrics';
 import { MockedVideoElement, resetDateNow, setupClient } from '../../../test';
 
-// const playbackUrl =
-//   'https://livepeercdn.com/recordings/9b8a9c59-e5c6-4ba8-9f88-e400b0f9153f/index.m3u8';
-
 describe('addMediaMetrics', () => {
   beforeAll(() => {
     setupClient();

--- a/packages/core/src/providers/studio/index.ts
+++ b/packages/core/src/providers/studio/index.ts
@@ -503,8 +503,6 @@ export class StudioLivepeerProvider extends BaseLivepeerProvider {
     return {
       ...studioStream,
       multistream: await this._mapToMultistream(studioStream.multistream),
-      rtmpIngestUrl: this._getRtmpIngestUrl(studioStream.streamKey),
-      playbackUrl: this._getPlaybackUrl(studioStream.playbackId),
     };
   }
 

--- a/packages/core/src/providers/studio/types.ts
+++ b/packages/core/src/providers/studio/types.ts
@@ -23,7 +23,7 @@ export type StudioFfmpegProfile = TranscodingProfile & {
 };
 
 export interface StudioStream
-  extends Omit<Stream, 'rtmpIngestUrl' | 'playbackUrl' | 'multistream'> {
+  extends Omit<Stream, 'playbackUrl' | 'multistream'> {
   profiles: StudioFfmpegProfile[];
   /**
    * Name of the token used to create this object.

--- a/packages/core/src/types/provider.ts
+++ b/packages/core/src/types/provider.ts
@@ -447,8 +447,6 @@ export type Stream = {
   rtmpIngestUrl: string;
   /** ID used to create the playback URLs */
   playbackId: string;
-  /** URL for HLS playback */
-  playbackUrl: string;
   /** ID of the parent stream object. Only present for sessions. */
   parentId?: string;
   /** Unix timestamp (in milliseconds) at which the stream object was created */


### PR DESCRIPTION
## Description

Removed `playbackUrl` from stream responses. Developers should migrate to using `playbackId` to query stream playback URLs.
