### PR TITLE
player/metrics: Make sure preloadTime is never negative

### DIFF
--- a/packages/core/src/media/metrics/metrics.ts
+++ b/packages/core/src/media/metrics/metrics.ts
@@ -335,7 +335,7 @@ export class MetricsStatus<TElement, TMediaStream> {
       offset: this.store.getState().playbackOffsetMs ?? 0,
 
       // this is the amount of time that a video has had to preload content, from boot until play was requested
-      preloadTime: this.requestedPlayTime,
+      preloadTime: Math.max(this.requestedPlayTime, 0),
       // time from when the first `play` event is emitted and the first progress update
       ttff:
         this.firstFrameTime > 0 && this.requestedPlayTime > 0


### PR DESCRIPTION

## Description

Observing some weird metrics reported by WebRTC load tester and this might fix it. Specifically, a bunch of viewership metrics are coming with a negative value for `preload_time`, and mist is consequentially ignoring those views.

## Additional Information

- [x] I read the [contributing docs](/livepeer/livepeer-react/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
