### PR TITLE
media/metrics: Avoid reporting preloadTime as 0

### DIFF
--- a/.changeset/chatty-moons-exercise.md
+++ b/.changeset/chatty-moons-exercise.md
@@ -1,0 +1,9 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+'@livepeer/core-web': patch
+'@livepeer/react': patch
+'@livepeer/react-native': patch
+---
+
+**Fix:** fixed metrics to only send values when they are defined, to avoid filtering on the backend.

--- a/packages/core-web/src/media/browser/metrics.test.ts
+++ b/packages/core-web/src/media/browser/metrics.test.ts
@@ -25,32 +25,32 @@ describe('addMediaMetrics', () => {
       }
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-        {
-          "autoplay": "standard",
-          "duration": 0,
-          "firstPlayback": 0,
-          "nError": 0,
-          "nStalled": 0,
-          "nWaiting": 0,
-          "offset": 0,
-          "pageUrl": "http://localhost:3000/",
-          "playbackScore": null,
-          "player": "hls-1",
-          "playerHeight": null,
-          "playerWidth": null,
-          "preloadTime": 0,
-          "sourceType": "unknown",
-          "sourceUrl": null,
-          "timeStalled": 0,
-          "timeUnpaused": 0,
-          "timeWaiting": 0,
-          "ttff": 0,
-          "uid": "",
-          "userAgent": "UA",
-          "videoHeight": null,
-          "videoWidth": null,
-        }
-      `);
+          {
+            "autoplay": "standard",
+            "duration": null,
+            "firstPlayback": null,
+            "nError": null,
+            "nStalled": 0,
+            "nWaiting": 0,
+            "offset": null,
+            "pageUrl": "http://localhost:3000/",
+            "playbackScore": null,
+            "player": "hls-1",
+            "playerHeight": null,
+            "playerWidth": null,
+            "preloadTime": null,
+            "sourceType": "unknown",
+            "sourceUrl": null,
+            "timeStalled": 0,
+            "timeUnpaused": 0,
+            "timeWaiting": 0,
+            "ttff": null,
+            "uid": "",
+            "userAgent": "UA",
+            "videoHeight": null,
+            "videoWidth": null,
+          }
+        `);
     });
 
     it('should update time unpaused and first playback', async () => {
@@ -72,24 +72,24 @@ describe('addMediaMetrics', () => {
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
         {
           "autoplay": "standard",
-          "duration": 0,
-          "firstPlayback": 0,
-          "nError": 0,
+          "duration": null,
+          "firstPlayback": null,
+          "nError": null,
           "nStalled": 0,
           "nWaiting": 0,
-          "offset": 0,
+          "offset": null,
           "pageUrl": "http://localhost:3000/",
           "playbackScore": null,
           "player": "hls-1",
           "playerHeight": null,
           "playerWidth": null,
-          "preloadTime": 0,
+          "preloadTime": null,
           "sourceType": "unknown",
           "sourceUrl": null,
           "timeStalled": 0,
           "timeUnpaused": 0,
           "timeWaiting": 0,
-          "ttff": 0,
+          "ttff": null,
           "uid": "",
           "userAgent": "UA",
           "videoHeight": null,
@@ -115,32 +115,32 @@ describe('addMediaMetrics', () => {
       }
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-            {
-              "autoplay": "standard",
-              "duration": 0,
-              "firstPlayback": 0,
-              "nError": 0,
-              "nStalled": 0,
-              "nWaiting": 1,
-              "offset": 0,
-              "pageUrl": "http://localhost:3000/",
-              "playbackScore": null,
-              "player": "hls-1",
-              "playerHeight": null,
-              "playerWidth": null,
-              "preloadTime": 0,
-              "sourceType": "unknown",
-              "sourceUrl": null,
-              "timeStalled": 0,
-              "timeUnpaused": 0,
-              "timeWaiting": 1000,
-              "ttff": 0,
-              "uid": "",
-              "userAgent": "UA",
-              "videoHeight": null,
-              "videoWidth": null,
-            }
-          `);
+      {
+        "autoplay": "standard",
+        "duration": null,
+        "firstPlayback": null,
+        "nError": null,
+        "nStalled": 0,
+        "nWaiting": 1,
+        "offset": null,
+        "pageUrl": "http://localhost:3000/",
+        "playbackScore": null,
+        "player": "hls-1",
+        "playerHeight": null,
+        "playerWidth": null,
+        "preloadTime": null,
+        "sourceType": "unknown",
+        "sourceUrl": null,
+        "timeStalled": 0,
+        "timeUnpaused": 0,
+        "timeWaiting": 1000,
+        "ttff": null,
+        "uid": "",
+        "userAgent": "UA",
+        "videoHeight": null,
+        "videoWidth": null,
+      }
+    `);
     });
 
     it('should update time stalled and stalled count', async () => {
@@ -162,32 +162,32 @@ describe('addMediaMetrics', () => {
       }
 
       expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-                {
-                  "autoplay": "standard",
-                  "duration": 0,
-                  "firstPlayback": 0,
-                  "nError": 0,
-                  "nStalled": 1,
-                  "nWaiting": 0,
-                  "offset": 0,
-                  "pageUrl": "http://localhost:3000/",
-                  "playbackScore": null,
-                  "player": "hls-1",
-                  "playerHeight": null,
-                  "playerWidth": null,
-                  "preloadTime": 0,
-                  "sourceType": "unknown",
-                  "sourceUrl": null,
-                  "timeStalled": 1000,
-                  "timeUnpaused": 0,
-                  "timeWaiting": 0,
-                  "ttff": 0,
-                  "uid": "",
-                  "userAgent": "UA",
-                  "videoHeight": null,
-                  "videoWidth": null,
-                }
-              `);
+                    {
+                      "autoplay": "standard",
+                      "duration": null,
+                      "firstPlayback": null,
+                      "nError": null,
+                      "nStalled": 1,
+                      "nWaiting": 0,
+                      "offset": null,
+                      "pageUrl": "http://localhost:3000/",
+                      "playbackScore": null,
+                      "player": "hls-1",
+                      "playerHeight": null,
+                      "playerWidth": null,
+                      "preloadTime": null,
+                      "sourceType": "unknown",
+                      "sourceUrl": null,
+                      "timeStalled": 1000,
+                      "timeUnpaused": 0,
+                      "timeWaiting": 0,
+                      "ttff": null,
+                      "uid": "",
+                      "userAgent": "UA",
+                      "videoHeight": null,
+                      "videoWidth": null,
+                    }
+                  `);
     });
   });
 
@@ -209,31 +209,31 @@ describe('addMediaMetrics', () => {
     }
 
     expect(metricsSnapshot?.current).toMatchInlineSnapshot(`
-            {
-              "autoplay": "standard",
-              "duration": 0,
-              "firstPlayback": 0,
-              "nError": 0,
-              "nStalled": 0,
-              "nWaiting": 0,
-              "offset": 0,
-              "pageUrl": "http://localhost:3000/",
-              "playbackScore": null,
-              "player": "hls-1",
-              "playerHeight": null,
-              "playerWidth": null,
-              "preloadTime": 0,
-              "sourceType": "unknown",
-              "sourceUrl": null,
-              "timeStalled": 0,
-              "timeUnpaused": 0,
-              "timeWaiting": 0,
-              "ttff": 0,
-              "uid": "",
-              "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36",
-              "videoHeight": null,
-              "videoWidth": null,
-            }
-          `);
+                    {
+                      "autoplay": "standard",
+                      "duration": null,
+                      "firstPlayback": null,
+                      "nError": null,
+                      "nStalled": 0,
+                      "nWaiting": 0,
+                      "offset": null,
+                      "pageUrl": "http://localhost:3000/",
+                      "playbackScore": null,
+                      "player": "hls-1",
+                      "playerHeight": null,
+                      "playerWidth": null,
+                      "preloadTime": null,
+                      "sourceType": "unknown",
+                      "sourceUrl": null,
+                      "timeStalled": 0,
+                      "timeUnpaused": 0,
+                      "timeWaiting": 0,
+                      "ttff": null,
+                      "uid": "",
+                      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36",
+                      "videoHeight": null,
+                      "videoWidth": null,
+                    }
+                  `);
   });
 });

--- a/packages/core/src/media/metrics/metrics.ts
+++ b/packages/core/src/media/metrics/metrics.ts
@@ -3,7 +3,7 @@ import { MediaControllerStore } from '../controller';
 import { MimeType } from '../mime';
 
 type RawMetrics = {
-  preloadTime: number;
+  preloadTime?: number;
   ttff: number;
   firstPlayback: number;
 
@@ -178,8 +178,8 @@ function isInIframe() {
 }
 
 export class MetricsStatus<TElement, TMediaStream> {
-  requestedPlayTime = 0;
-  firstFrameTime = 0;
+  requestedPlayTime?: number;
+  firstFrameTime?: number;
 
   retryCount = 0;
   connected = false;
@@ -233,7 +233,6 @@ export class MetricsStatus<TElement, TMediaStream> {
       sourceUrl: currentState?.src?.src ?? null,
       playerHeight: null,
       playerWidth: null,
-      preloadTime: 0,
       timeStalled: 0,
       timeUnpaused: 0,
       timeWaiting: 0,
@@ -248,7 +247,7 @@ export class MetricsStatus<TElement, TMediaStream> {
     };
 
     this.destroy = store.subscribe((state, prevState) => {
-      if (this.requestedPlayTime === 0 && state._playLastTime !== 0) {
+      if (this.requestedPlayTime === undefined && state._playLastTime !== 0) {
         this.requestedPlayTime = Math.max(state._playLastTime - bootMs, 0);
       }
 
@@ -335,10 +334,11 @@ export class MetricsStatus<TElement, TMediaStream> {
       offset: this.store.getState().playbackOffsetMs ?? 0,
 
       // this is the amount of time that a video has had to preload content, from boot until play was requested
-      preloadTime: Math.max(this.requestedPlayTime, 0),
+      preloadTime: this.requestedPlayTime,
       // time from when the first `play` event is emitted and the first progress update
       ttff:
-        this.firstFrameTime > 0 && this.requestedPlayTime > 0
+        this.firstFrameTime !== undefined &&
+        this.requestedPlayTime !== undefined
           ? Math.max(this.firstFrameTime - this.requestedPlayTime, 0)
           : 0,
     };
@@ -542,7 +542,7 @@ export function addMediaMetricsToStore<TElement, TMediaStream>(
 
       if (
         state.progress !== prevState.progress &&
-        metricsStatus.getFirstFrameTime() === 0
+        metricsStatus.getFirstFrameTime() === undefined
       ) {
         metricsStatus.setFirstFrameTime();
       }

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,6 +1,6 @@
-const core = `@livepeer/core@2.0.1`;
-const react = `@livepeer/react@3.0.1`;
-const reactNative = `@livepeer/react-native@2.0.1`;
+const core = `@livepeer/core@2.0.3`;
+const react = `@livepeer/react@3.0.3`;
+const reactNative = `@livepeer/react-native@2.0.3`;
 
 export const version = {
   core,


### PR DESCRIPTION
## Description

This is to circumvent a limitation in Mist's current websocket handling code, which disregards any observation of a metric that is higher than the previous observation by 6000 ([source](https://github.com/livepeer/mistserver/blob/catalyst/src/output/output_http_internal.cpp#L1181)). It not only disregards the specific metric, but it actually flags the entire viewership session as invalid, and we ignore the view from our viewership pipeline.

While the Mist behavior is not fixed, this is a way to avoid the problem with the `preloadTime` metric, which is the current one we're getting tons of views discarded by. This metric is always reported with a value of `0` in the beginning of the session, and only when the playback is requested it gets updated with the time difference. The biggest problem is that if this takes 6s (6000 milliseconds), the entire view session will be flagged invalid by Mist the websocket code.

The fix here is to initialize the corresponding metrics as `undefined` instead of `0`, so they don't get serialized on the JSON sent to Mist. This will avoid the error because it won't be a 0 value then a >6000 value reported, but it just gets reported as the final value once we have it.

## Additional Information

- [x] I read the [contributing docs](/livepeer/livepeer-react/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
