### PR TITLE
Add track selectors

### DIFF
--- a/.changeset/stale-tigers-buy.md
+++ b/.changeset/stale-tigers-buy.md
@@ -1,0 +1,18 @@
+---
+'@livepeer/core': patch
+'@livepeer/core-web': patch
+'@livepeer/core-react': patch
+'@livepeer/react': patch
+---
+
+**Feature:** added track selectors to WebRTC so developers can override video and audio tracks.
+
+```tsx
+<Player
+  webrtcConfig={{
+    videoTrackSelector: '~1280x720',
+  }}
+/>
+```
+
+See [here](https://docs.mistserver.org/mistserver/concepts/track_selectors/) for more documentation.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.options": {
     "extensions": [".js", ".json", ".md", ".mdx", ".ts", ".tsx"]

--- a/packages/core-web/src/media/browser/webrtc/shared.ts
+++ b/packages/core-web/src/media/browser/webrtc/shared.ts
@@ -1,4 +1,8 @@
-import { NOT_ACCEPTABLE_ERROR_MESSAGE } from '@livepeer/core';
+import {
+  AudioTrackSelector,
+  NOT_ACCEPTABLE_ERROR_MESSAGE,
+  VideoTrackSelector,
+} from '@livepeer/core';
 import fetch from 'cross-fetch';
 
 import { isClient } from '../utils';
@@ -82,6 +86,18 @@ export type WebRTCVideoConfig = {
    * Disables the speedup/slowdown mechanic in WebRTC, to allow for non-distorted audio.
    */
   constant?: boolean;
+  /**
+   * The track selector used when choosing the video track for playback.
+   *
+   * @docs https://docs.mistserver.org/mistserver/concepts/track_selectors/
+   */
+  videoTrackSelector?: VideoTrackSelector;
+  /**
+   * The track selector used when choosing the audio track for playback.
+   *
+   * @docs https://docs.mistserver.org/mistserver/concepts/track_selectors/
+   */
+  audioTrackSelector?: AudioTrackSelector;
 };
 
 const DEFAULT_TIMEOUT = 20000;
@@ -172,13 +188,21 @@ async function postSDPOffer(
     config?.sdpTimeout ?? DEFAULT_TIMEOUT,
   );
 
+  const url = new URL(endpoint);
+
   if (config?.constant) {
-    const url = new URL(endpoint);
     url.searchParams.append('constant', 'true');
-    endpoint = url.toString();
   }
 
-  const response = await fetch(endpoint, {
+  if (config?.audioTrackSelector) {
+    url.searchParams.append('audio', config.audioTrackSelector);
+  }
+
+  if (config?.videoTrackSelector) {
+    url.searchParams.append('video', config.videoTrackSelector);
+  }
+
+  const response = await fetch(url.toString(), {
     method: 'POST',
     mode: 'cors',
     headers: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
 } from './media';
 export type {
   AudioSrc,
+  AudioTrackSelector,
   Base64Src,
   ClipLength,
   ControlsOptions,
@@ -56,8 +57,12 @@ export type {
   ObjectFit,
   PlaybackError,
   PlaybackMonitor,
+  SingleAudioTrackSelector,
+  SingleTrackSelector,
+  SingleVideoTrackSelector,
   Src,
   VideoSrc,
+  VideoTrackSelector,
   WebRTCSrc,
 } from './media';
 export { createStorage, noopStorage } from './storage';

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -23,10 +23,15 @@ export type { MediaMetrics, MetricsStatus, PlaybackMonitor } from './metrics';
 export { getMediaSourceType } from './src';
 export type {
   AudioSrc,
+  AudioTrackSelector,
   Base64Src,
   HlsSrc,
+  SingleAudioTrackSelector,
+  SingleTrackSelector,
+  SingleVideoTrackSelector,
   Src,
   VideoSrc,
+  VideoTrackSelector,
   WebRTCSrc,
 } from './src';
 export { aspectRatios } from './theme';

--- a/packages/core/src/media/src.ts
+++ b/packages/core/src/media/src.ts
@@ -47,6 +47,108 @@ export interface WebRTCSrc extends BaseSrc {
 }
 export type Src = AudioSrc | HlsSrc | VideoSrc | Base64Src | WebRTCSrc;
 
+/**
+ * Represents a single track selector
+ */
+export type SingleTrackSelector =
+  /** Selects no tracks */
+  | 'none'
+  /** Selects all tracks */
+  | 'all'
+  /** Selects all tracks */
+  | '*'
+  /** Specific track ID */
+  | `${number}`
+  /** Highest bit rate */
+  | 'maxbps'
+  /** Lowest bit rate */
+  | 'minbps'
+  /** Specific bit rate */
+  | `${number}bps`
+  /** Specific bit rate */
+  | `${number}kbps`
+  /** Specific bit rate */
+  | `${number}mbps`
+  /** Greater than specific bit rate */
+  | `>${number}bps`
+  /** Greater than specific bit rate */
+  | `>${number}kbps`
+  /** Greater than specific bit rate */
+  | `>${number}mbps`
+  /** Less than specific bit rate */
+  | `<${number}bps`
+  /** Less than specific bit rate */
+  | `<${number}kbps`
+  /** Less than specific bit rate */
+  | `<${number}mbps`
+  /** Max less than specific bit rate */
+  | `max<${number}bps`
+  /** Max less than specific bit rate */
+  | `max<${number}kbps`
+  /** Max less than specific bit rate */
+  | `max<${number}mbps`;
+
+/**
+ * Represents a single audio track selector
+ */
+export type SingleAudioTrackSelector =
+  | SingleTrackSelector
+  /** Channel count */
+  | 'surround'
+  /** Channel count */
+  | 'mono'
+  /** Channel count */
+  | 'stereo'
+  /** Channel count */
+  | `${number}ch`;
+
+/**
+ * Represents a single video track selector
+ */
+export type SingleVideoTrackSelector =
+  | SingleTrackSelector
+  /** Highest pixel surface area */
+  | 'maxres'
+  /** Lowest pixel surface area */
+  | 'minres'
+  /** Specific pixel surface area */
+  | `${number}x${number}`
+  /** Closest to specific pixel surface area */
+  | `~${number}x${number}`
+  /** Greater than pixel surface area */
+  | `>${number}x${number}`
+  /** Less than pixel surface area */
+  | `<${number}x${number}`
+  /** Resolution */
+  | '720p'
+  /** Resolution */
+  | '1080p'
+  /** Resolution */
+  | '1440p'
+  /** Resolution */
+  | '2k'
+  /** Resolution */
+  | '4k'
+  /** Resolution */
+  | '5k'
+  /** Resolution */
+  | '8k';
+
+/**
+ * Generic track selector for a given type
+ */
+type TrackSelector<T extends string> =
+  | T
+  /** Union of selectors */
+  | `${T},${T}`
+  /** Difference of selectors */
+  | `${T},!${T}`
+  /** Intersection of selectors */
+  | `${T},|${T}`;
+
+export type VideoTrackSelector = TrackSelector<SingleVideoTrackSelector>;
+export type AudioTrackSelector = TrackSelector<SingleAudioTrackSelector>;
+
 const audioExtensions =
   /\.(m4a|mp4a|mpga|mp2|mp2a|mp3|m2a|m3a|wav|weba|aac|oga|spx)($|\?)/i;
 const videoExtensions = /\.(mp4|ogv|webm|mov|m4v|avi|m3u8)($|\?)/i;


### PR DESCRIPTION
## Description

Added track selectors to WebRTC so developers can override video and audio tracks.

```tsx
<Player
  webrtcConfig={{
    videoTrackSelector: '~1280x720',
  }}
/>
```

See [here](https://docs.mistserver.org/mistserver/concepts/track_selectors/) for more documentation.
