### PR TITLE
Fix VPN Playback

### DIFF
--- a/.changeset/orange-fireants-prove.md
+++ b/.changeset/orange-fireants-prove.md
@@ -1,0 +1,22 @@
+---
+'@livepeer/core-web': patch
+'@livepeer/react': patch
+'@livepeer/core': patch
+'@livepeer/core-react': patch
+---
+
+**Fix:** resolves issue with VPNs transparently blocking WebRTC playback and failing to start.
+
+The timeout for playback can be customized with `webrtcConfig.canPlayTimeout`:
+
+```tsx
+import { Player, WebRTCVideoConfig } from '@livepeer/react';
+
+const webrtcConfig: WebRTCVideoConfig = {
+  canPlayTimeout: 8000,
+};
+
+const Page = () => {
+  return <Player playbackId={playbackId} webrtcConfig={webrtcConfig} />;
+};
+```

--- a/packages/core-web/src/media/browser/webrtc/shared.ts
+++ b/packages/core-web/src/media/browser/webrtc/shared.ts
@@ -93,6 +93,12 @@ export type WebRTCVideoConfig = {
    * @docs https://docs.mistserver.org/mistserver/concepts/track_selectors/
    */
   audioTrackSelector?: AudioTrackSelector;
+  /**
+   * The timeout of the time to wait for WebRTC canPlay, in ms.
+   *
+   * @default 5000
+   */
+  canPlayTimeout?: number;
 };
 
 const DEFAULT_TIMEOUT = 20000;

--- a/packages/core-web/src/media/browser/webrtc/shared.ts
+++ b/packages/core-web/src/media/browser/webrtc/shared.ts
@@ -94,9 +94,9 @@ export type WebRTCVideoConfig = {
    */
   audioTrackSelector?: AudioTrackSelector;
   /**
-   * The timeout of the time to wait for WebRTC canPlay, in ms.
+   * The timeout of the time to wait for WebRTC `canPlay`, in ms.
    *
-   * @default 5000
+   * @default 7000
    */
   canPlayTimeout?: number;
 };

--- a/packages/react/src/components/media/players/video/index.tsx
+++ b/packages/react/src/components/media/players/video/index.tsx
@@ -219,25 +219,28 @@ const InternalVideoPlayer = React.forwardRef<
   React.useEffect(() => {
     if (currentPlaybackSource) {
       store?.getState?.()?._updateSource?.(currentPlaybackSource?.src);
+    }
+  }, [store, currentPlaybackSource]);
 
-      if (currentPlaybackSource.type === 'webrtc') {
-        const id = setTimeout(() => {
-          if (!store.getState().canPlay) {
-            onPlaybackError(
-              new Error(
-                'Timeout reached for canPlay - triggering playback error.',
-              ),
-            );
-          }
-        }, webrtcConfig?.canPlayTimeout ?? 5000);
+  React.useEffect(() => {
+    if (!playbackError && currentPlaybackSource?.type === 'webrtc') {
+      const id = setTimeout(() => {
+        if (!store.getState().canPlay) {
+          onPlaybackError(
+            new Error(
+              'Timeout reached for canPlay - triggering playback error.',
+            ),
+          );
+        }
+      }, webrtcConfig?.canPlayTimeout ?? 7000);
 
-        return () => {
-          clearTimeout(id);
-        };
-      }
+      return () => {
+        clearTimeout(id);
+      };
     }
   }, [
     store,
+    playbackError,
     onPlaybackError,
     webrtcConfig?.canPlayTimeout,
     currentPlaybackSource,


### PR DESCRIPTION
## Description

Resolves issue with Safari Private Relay/VPNs transparently blocking WebRTC playback and failing to start.

The timeout for playback can be customized with `webrtcConfig.canPlayTimeout`:

```tsx
import { Player, WebRTCVideoConfig } from '@livepeer/react';

const webrtcConfig: WebRTCVideoConfig = {
  canPlayTimeout: 8000,
};

const Page = () => {
  return <Player playbackId={playbackId} webrtcConfig={webrtcConfig} />;
};
```
