### PR TITLE
Override getUserMedia

### DIFF
--- a/.changeset/perfect-cars-argue.md
+++ b/.changeset/perfect-cars-argue.md
@@ -1,0 +1,8 @@
+---
+"@livepeer/core-web": patch
+"@livepeer/core": patch
+"@livepeer/core-react": patch
+"@livepeer/react": patch
+---
+
+**Fix:** changed `getUserMedia` to override to request video when both audio and video are disabled, so that the Broadcast doesn't get stuck in a pending state.

--- a/.changeset/red-spiders-warn.md
+++ b/.changeset/red-spiders-warn.md
@@ -1,0 +1,8 @@
+---
+"@livepeer/core-web": patch
+"@livepeer/react": patch
+"@livepeer/core": patch
+"@livepeer/core-react": patch
+---
+
+**Fix:** fixed issue with `muted` Video prop and volume getting out of sync.

--- a/examples/next-pages/src/components/Player.tsx
+++ b/examples/next-pages/src/components/Player.tsx
@@ -81,6 +81,7 @@ export function PlayerWithControls({
     <div className="w-full max-w-2xl mx-auto">
       <Player.Root
         autoPlay
+        volume={0}
         aspectRatio={16 / 9}
         clipLength={30}
         src={src}

--- a/packages/core-web/src/broadcast.ts
+++ b/packages/core-web/src/broadcast.ts
@@ -823,9 +823,13 @@ const addEffectsToStore = (
         }
 
         if (!audio && !video) {
-          warn("Audio and video are both not enabled.");
+          warn(
+            "At least one of audio and video must be requested. Overriding video to be enabled so that `getUserMedia` can be requested.",
+          );
 
-          return;
+          store.setState({ video: true });
+
+          video = true;
         }
 
         const stream = await (requestedVideoDeviceId === "screen"

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -349,7 +349,7 @@ export type MediaControllerState = {
     requestSeekDiff: (difference: number) => void;
     requestSeekForward: (difference?: number) => void;
     requestToggleFullscreen: () => void;
-    requestToggleMute: () => void;
+    requestToggleMute: (forceValue?: boolean) => void;
     requestTogglePictureInPicture: () => void;
     requestVolume: (volume: number) => void;
     setAutohide: (autohide: number) => void;
@@ -890,19 +890,20 @@ export const createControllerStore = ({
                 },
               })),
 
-            requestToggleMute: () =>
+            requestToggleMute: (forceValue?: boolean) =>
               set(({ __controls }) => {
                 const previousVolume = getBoundedVolume(__controls.volume) || 0;
+                const nonMutedVolume =
+                  previousVolume > 0.01 ? previousVolume : DEFAULT_VOLUME_LEVEL;
+                const mutedVolume = 0;
+
+                const newMutedValue = forceValue ?? !__controls.muted;
 
                 return {
-                  volume: !__controls.muted
-                    ? 0
-                    : previousVolume > 0.01
-                      ? previousVolume
-                      : DEFAULT_VOLUME_LEVEL,
+                  volume: newMutedValue ? mutedVolume : nonMutedVolume,
                   __controls: {
                     ...__controls,
-                    muted: !__controls.muted,
+                    muted: newMutedValue,
                   },
                 };
               }),
@@ -1094,7 +1095,7 @@ export const createControllerStore = ({
         store.getState().__controlsFunctions.setVideoQuality(videoQuality);
       }
       if (volume !== store.getState().volume) {
-        store.getState().__controlsFunctions.setVolume(volume);
+        store.getState().__controlsFunctions.requestVolume(volume);
       }
     },
   );

--- a/packages/react/src/player/Video.tsx
+++ b/packages/react/src/player/Video.tsx
@@ -50,6 +50,7 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
       preload,
       thumbnailPoster,
       volume,
+      requestToggleMute,
     } = useStore(
       context.store,
       useShallow(
@@ -68,6 +69,7 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
           setMounted: __controlsFunctions.setMounted,
           thumbnailPoster: poster,
           volume,
+          requestToggleMute: __controlsFunctions.requestToggleMute,
         }),
       ),
     );
@@ -91,6 +93,12 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
       // we run this on mount to initialize playback
       setMounted();
     }, [setMounted]);
+
+    useEffect(() => {
+      if (typeof videoProps.muted !== "undefined") {
+        requestToggleMute(videoProps.muted);
+      }
+    }, [videoProps.muted, requestToggleMute]);
 
     return (
       <Radix.Primitive.video


### PR DESCRIPTION
## Description

Changed `getUserMedia` to override to request video when both audio and video are disabled, so that the Broadcast doesn't get stuck in a pending state.
