### PR TITLE
fix: mouse interactions

### DIFF
--- a/.changeset/weak-teachers-own.md
+++ b/.changeset/weak-teachers-own.md
@@ -1,0 +1,8 @@
+---
+"@livepeer/core-web": patch
+"@livepeer/core": patch
+"@livepeer/core-react": patch
+"@livepeer/react": patch
+---
+
+**Fix:** fixed the mouse interactions to not hide when a Radix Popover is open, and not flash when a user hovers over the video element.

--- a/examples/next/src/app/livepeer.ts
+++ b/examples/next/src/app/livepeer.ts
@@ -7,6 +7,7 @@ import { cache } from "react";
 
 const livepeer = new Livepeer({
   apiKey: process.env.STUDIO_API_KEY ?? "",
+  serverURL: process.env.STUDIO_BASE_URL,
 });
 
 const livepeerPrivateKey = process.env.LIVEPEER_JWT_PRIVATE_KEY ?? "";

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -249,8 +249,6 @@ export const addEventListeners = (
     element.addEventListener("loadstart", onLoadStart);
     element.addEventListener("ended", onEnded);
 
-    parentElementOrElement?.addEventListener("mouseover", onMouseUpdate);
-    parentElementOrElement?.addEventListener("mouseenter", onMouseUpdate);
     parentElementOrElement?.addEventListener("mouseout", onMouseUpdate);
     parentElementOrElement?.addEventListener("mousemove", onMouseUpdate);
 
@@ -323,11 +321,6 @@ export const addEventListeners = (
         window?.removeEventListener?.("resize", onResize);
       }
 
-      parentElementOrElement?.removeEventListener?.("mouseover", onMouseUpdate);
-      parentElementOrElement?.removeEventListener?.(
-        "mouseenter",
-        onMouseUpdate,
-      );
       parentElementOrElement?.removeEventListener?.("mouseout", onMouseUpdate);
       parentElementOrElement?.removeEventListener?.("mousemove", onMouseUpdate);
 
@@ -705,7 +698,18 @@ const addEffectsToStore = (
 
         await delay(autohide);
 
+        const parentElementOrElement = element?.parentElement ?? element;
+
+        // we check if any children of the parent element are in an "open" state, which is the radix
+        // data attribute for popovers and other elements
+        // this is the only way to reliably hide the controls while a popover is shown, and possibly
+        // is missing some data attributes for other primitives
+        const openElement = parentElementOrElement?.querySelector?.(
+          '[data-state="open"]',
+        );
+
         if (
+          !openElement &&
           !store.getState().hidden &&
           lastInteraction === store.getState().__controls.lastInteraction
         ) {

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,5 +1,5 @@
-const core = "@livepeer/core@3.1.6";
-const react = "@livepeer/react@4.1.6";
+const core = "@livepeer/core@3.1.7";
+const react = "@livepeer/react@4.1.7";
 
 export const version = {
   core,


### PR DESCRIPTION
## Description

Fixed the mouse interactions to not hide when a Radix Popover is open, and not flash when a user hovers over the video element.
