### PR TITLE
fix: add backoff cap and props

### DIFF
--- a/.changeset/tidy-eggs-fold.md
+++ b/.changeset/tidy-eggs-fold.md
@@ -1,0 +1,20 @@
+---
+"@livepeer/core-web": patch
+"@livepeer/core": patch
+"@livepeer/core-react": patch
+"@livepeer/react": patch
+---
+
+**Feature:** added `backoff` and `backoffMax` to the Player, which defines the time which the Player waits before attempting, as well as the cap for exponential backoff.
+
+```tsx
+/**
+ * Controls the initial value for exponential backoff, in ms. Defaults to 500ms, which is subsequently multiplied by 2^n power on each error.
+ */
+backoff: number;
+
+/**
+ * Controls the maximum backoff when an error is encountered, in ms. Defaults to 30s.
+ */
+backoffMax: number;
+```

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -394,10 +394,7 @@ const addEffectsToStore = (
       await cleanupSource?.();
 
       if (errorCount > 0) {
-        const delayTime = Math.max(
-          Math.min(backoff * 2 ** (errorCount - 1), backoffMax),
-          100,
-        );
+        const delayTime = Math.min(backoff * 2 ** (errorCount - 1), backoffMax);
         await delay(delayTime);
       }
 

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -358,13 +358,14 @@ const addEffectsToStore = (
       __controls,
       currentSource,
       errorCount,
-      live,
       progress,
       mounted,
       videoQuality,
     }) => ({
       aspectRatio: __initialProps.aspectRatio,
       autoPlay: __initialProps.autoPlay,
+      backoff: __initialProps.backoff,
+      backoffMax: __initialProps.backoffMax,
       errorCount,
       hlsConfig: __controls.hlsConfig,
       mounted,
@@ -376,6 +377,8 @@ const addEffectsToStore = (
     async ({
       aspectRatio,
       autoPlay,
+      backoff,
+      backoffMax,
       errorCount,
       hlsConfig,
       mounted,
@@ -391,7 +394,7 @@ const addEffectsToStore = (
       await cleanupSource?.();
 
       if (errorCount > 0) {
-        const delayTime = 500 * 2 ** (errorCount - 1);
+        const delayTime = Math.min(backoff * 2 ** (errorCount - 1), backoffMax);
         await delay(delayTime);
       }
 

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -394,7 +394,10 @@ const addEffectsToStore = (
       await cleanupSource?.();
 
       if (errorCount > 0) {
-        const delayTime = Math.min(backoff * 2 ** (errorCount - 1), backoffMax);
+        const delayTime = Math.max(
+          Math.min(backoff * 2 ** (errorCount - 1), backoffMax),
+          100,
+        );
         await delay(delayTime);
       }
 

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -51,6 +51,8 @@ export type InitialProps = {
 
   /**
    * Controls the initial value for exponential backoff, in ms. Defaults to 500ms, which is subsequently multiplied by 2^n power on each error.
+   *
+   * This is limited at a minimum of 100ms.
    */
   backoff: number;
 

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -50,6 +50,16 @@ export type InitialProps = {
   autoPlay: boolean;
 
   /**
+   * Controls the initial value for exponential backoff, in ms. Defaults to 500ms, which is subsequently multiplied by 2^n power on each error.
+   */
+  backoff: number;
+
+  /**
+   * Controls the maximum backoff when an error is encountered, in ms. Defaults to 30s.
+   */
+  backoffMax: number;
+
+  /**
    * The length of the clip. This is usually used alongside `ClipTrigger`. Specifies the duration of the media clip, in seconds.
    *
    * Set to `null` to disable the ClipTrigger.
@@ -552,6 +562,8 @@ export const createControllerStore = ({
             accessKey: initialProps.accessKey ?? null,
             aspectRatio: initialProps?.aspectRatio ?? null,
             autoPlay: initialProps.autoPlay ?? false,
+            backoff: initialProps.backoff ?? 500,
+            backoffMax: initialProps.backoffMax ?? 30000,
             clipLength: initialProps.clipLength ?? null,
             hotkeys: initialProps?.hotkeys ?? true,
             jwt: initialProps.jwt ?? null,

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -566,7 +566,7 @@ export const createControllerStore = ({
             accessKey: initialProps.accessKey ?? null,
             aspectRatio: initialProps?.aspectRatio ?? null,
             autoPlay: initialProps.autoPlay ?? false,
-            backoff: initialProps.backoff ?? 500,
+            backoff: Math.max(initialProps.backoff ?? 500, 100),
             backoffMax: Math.max(initialProps.backoffMax ?? 30000, 10000),
             clipLength: initialProps.clipLength ?? null,
             hotkeys: initialProps?.hotkeys ?? true,

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -58,6 +58,8 @@ export type InitialProps = {
 
   /**
    * Controls the maximum backoff when an error is encountered, in ms. Defaults to 30s.
+   *
+   * This is limited at a minimum of 10s, to prevent DDoS when a popular stream goes down.
    */
   backoffMax: number;
 
@@ -565,7 +567,7 @@ export const createControllerStore = ({
             aspectRatio: initialProps?.aspectRatio ?? null,
             autoPlay: initialProps.autoPlay ?? false,
             backoff: initialProps.backoff ?? 500,
-            backoffMax: initialProps.backoffMax ?? 30000,
+            backoffMax: Math.max(initialProps.backoffMax ?? 30000, 10000),
             clipLength: initialProps.clipLength ?? null,
             hotkeys: initialProps?.hotkeys ?? true,
             jwt: initialProps.jwt ?? null,


### PR DESCRIPTION
## Description

Added `backoff` and `backoffMax` to the Player, which defines the time which the Player waits before attempting, as well as the cap for exponential backoff.

```tsx
/**
 * Controls the initial value for exponential backoff, in ms. Defaults to 500ms, which is subsequently multiplied by 2^n power on each error.
 */
backoff: number;

/**
 * Controls the maximum backoff when an error is encountered, in ms. Defaults to 30s.
 */
backoffMax: number;
```
