### PR TITLE
fix: remove element load

### DIFF
--- a/.changeset/chilled-rabbits-flash.md
+++ b/.changeset/chilled-rabbits-flash.md
@@ -1,0 +1,8 @@
+---
+"@livepeer/core-web": patch
+"@livepeer/core": patch
+"@livepeer/core-react": patch
+"@livepeer/react": patch
+---
+
+**Fix:** removed `element.load()` side effect from the `addEventListeners` function.

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -263,8 +263,6 @@ export const addEventListeners = (
     parentElementOrElement?.addEventListener("keyup", onKeyUp);
     parentElementOrElement?.setAttribute("tabindex", "0");
 
-    element.load();
-
     element.setAttribute(MEDIA_CONTROLLER_INITIALIZED_ATTRIBUTE, "true");
   }
 

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,5 +1,5 @@
-const core = "@livepeer/core@3.1.10";
-const react = "@livepeer/react@4.1.10";
+const core = "@livepeer/core@3.1.11";
+const react = "@livepeer/react@4.1.11";
 
 export const version = {
   core,


### PR DESCRIPTION
## Description

Removed `element.load()` side effect from the `addEventListeners` function.

Fixes https://linear.app/livepeer/issue/PS-411/error-when-calling-addmediametrics-after-calling-load-method-in