### PR TITLE
fix: storage override

### DIFF
--- a/.changeset/moody-shirts-cover.md
+++ b/.changeset/moody-shirts-cover.md
@@ -1,0 +1,8 @@
+---
+"@livepeer/core-react": patch
+"@livepeer/core-web": patch
+"@livepeer/react": patch
+"@livepeer/core": patch
+---
+
+**Fix:** resolved an issue where a `storage` override was not being respected.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "cSpell.words": ["Arweave", "multistream"],
   "json.format.enable": false
 }

--- a/packages/react/src/broadcast/Broadcast.tsx
+++ b/packages/react/src/broadcast/Broadcast.tsx
@@ -61,15 +61,17 @@ const Broadcast = (
   const mediaStore = useRef(
     createControllerStore({
       device: getDeviceInfo(version.react),
-      storage: createStorage(
-        storage !== null && typeof window !== "undefined"
-          ? {
-              storage: window.localStorage,
-            }
-          : {
-              storage: noopStorage,
-            },
-      ),
+      storage:
+        storage ??
+        createStorage(
+          storage !== null && typeof window !== "undefined"
+            ? {
+                storage: window.localStorage,
+              }
+            : {
+                storage: noopStorage,
+              },
+        ),
       src: null,
       initialProps: {
         hotkeys: "broadcast",
@@ -85,15 +87,17 @@ const Broadcast = (
   const broadcastStore = useRef(
     createBroadcastStore({
       device: getBroadcastDeviceInfo(version.react),
-      storage: createStorage(
-        storage !== null && typeof window !== "undefined"
-          ? {
-              storage: window.localStorage,
-            }
-          : {
-              storage: noopStorage,
-            },
-      ),
+      storage:
+        storage ??
+        createStorage(
+          storage !== null && typeof window !== "undefined"
+            ? {
+                storage: window.localStorage,
+              }
+            : {
+                storage: noopStorage,
+              },
+        ),
       ingestUrl,
       initialProps: {
         aspectRatio,

--- a/packages/react/src/player/Player.tsx
+++ b/packages/react/src/player/Player.tsx
@@ -56,15 +56,17 @@ const Player = React.memo((props: MediaScopedProps<PlayerProps>) => {
   const store = useRef(
     createControllerStore({
       device: getDeviceInfo(version.react),
-      storage: createStorage(
-        storage !== null && typeof window !== "undefined"
-          ? {
-              storage: window.localStorage,
-            }
-          : {
-              storage: noopStorage,
-            },
-      ),
+      storage:
+        storage ??
+        createStorage(
+          storage !== null && typeof window !== "undefined"
+            ? {
+                storage: window.localStorage,
+              }
+            : {
+                storage: noopStorage,
+              },
+        ),
       src,
       initialProps: {
         aspectRatio,


### PR DESCRIPTION
## Description

Resolved an issue where a `storage` override was not being respected.