### PR TITLE
Bugfix: Only set poster live update interval when greater than 0

### DIFF
--- a/.changeset/sweet-readers-flash.md
+++ b/.changeset/sweet-readers-flash.md
@@ -1,0 +1,5 @@
+---
+"@livepeer/core-web": patch
+---
+
+only set poster live update interval when greater than 0

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -611,7 +611,7 @@ const addEffectsToStore = (
     async ({ thumbnail, live, setPoster, posterLiveUpdate }) => {
       cleanupPosterImage?.();
 
-      if (thumbnail && live) {
+      if (thumbnail && live && posterLiveUpdate > 0) {
         const interval = setInterval(() => {
           const thumbnailUrl = new URL(thumbnail);
 


### PR DESCRIPTION
## Description

If the `posterLiveUpdate` is set to `0`, it will request a new thumbnail poster every `0` seconds. This change only starts the interval if the `posterLiveUpdate` is greater than 0.

## Additional Information

- [ Yes] I read the [contributing docs](/livepeer/ui-kit/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
