### PR TITLE
Add backoffMax search param to lvpr.tv

### DIFF
--- a/.changeset/yellow-turtles-attend.md
+++ b/.changeset/yellow-turtles-attend.md
@@ -1,0 +1,5 @@
+---
+"@livepeer/core": patch
+---
+
+Decrease the minimal value of backoffMax from 10s to 1s

--- a/apps/lvpr-tv/src/app/page.tsx
+++ b/apps/lvpr-tv/src/app/page.tsx
@@ -24,6 +24,7 @@ type PlayerSearchParams = {
   muted?: Muted;
   loop?: Loop;
   lowLatency?: LowLatency;
+  backoffMax?: number;
   objectFit?: ObjectFit;
   constant?: Constant;
   clipLength?: ClipLength;
@@ -51,6 +52,7 @@ export default async function PlayerPage({
       searchParams?.lowLatency === "force"
         ? "force"
         : coerceToBoolean(searchParams?.lowLatency, true),
+    backoffMax: searchParams?.backoffMax ?? null,
     objectFit: searchParams?.objectFit ?? "contain",
     clipLength: searchParams?.clipLength
       ? (Number(searchParams.clipLength) as ClipLength)

--- a/apps/lvpr-tv/src/components/player/Player.tsx
+++ b/apps/lvpr-tv/src/components/player/Player.tsx
@@ -98,7 +98,7 @@ export async function PlayerWithControls(props: PlayerProps) {
       autoPlay={props.autoplay}
       volume={props.muted ? 0 : undefined}
       lowLatency={props.lowLatency}
-      backoffMax={props.backoffMax ?? null}
+      backoffMax={props.backoffMax ?? undefined}
       clipLength={props.clipLength ?? null}
       playbackRate={props.constant ? "constant" : undefined}
       jwt={props.jwt}

--- a/apps/lvpr-tv/src/components/player/Player.tsx
+++ b/apps/lvpr-tv/src/components/player/Player.tsx
@@ -30,6 +30,7 @@ export type PlayerProps = Partial<{
   muted: boolean;
   loop: boolean;
   lowLatency: boolean | "force";
+  backoffMax: number | null;
   objectFit: "cover" | "contain";
   constant: boolean;
   clipLength: ClipLength | null;
@@ -97,6 +98,7 @@ export async function PlayerWithControls(props: PlayerProps) {
       autoPlay={props.autoplay}
       volume={props.muted ? 0 : undefined}
       lowLatency={props.lowLatency}
+      backoffMax={props.backoffMax ?? null}
       clipLength={props.clipLength ?? null}
       playbackRate={props.constant ? "constant" : undefined}
       jwt={props.jwt}

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -643,7 +643,7 @@ export const createControllerStore = ({
             aspectRatio: initialProps?.aspectRatio ?? null,
             autoPlay: initialProps.autoPlay ?? false,
             backoff: Math.max(initialProps.backoff ?? 500, 100),
-            backoffMax: Math.max(initialProps.backoffMax ?? 30000, 10000),
+            backoffMax: Math.max(initialProps.backoffMax ?? 30000, 1000),
             clipLength: initialProps.clipLength ?? null,
             cacheWebRTCFailureMs: initialProps.cacheWebRTCFailureMs ?? null,
             hotkeys: initialProps?.hotkeys ?? true,


### PR DESCRIPTION
## Description

We use iframe in lvpr.tv in Livepeer Pipelines which needs to refresh every 1s (not backoff to 30s delay which slows down the stream startup time).

## Additional Information

- [x] I read the [contributing docs](/livepeer/ui-kit/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
