### PR TITLE
Don't cache redirect for ingest playback

### DIFF
--- a/packages/core-web/src/webrtc/shared.ts
+++ b/packages/core-web/src/webrtc/shared.ts
@@ -273,7 +273,9 @@ export async function getRedirectUrl(
         playbackIdPattern,
         `$1${REPLACE_PLACEHOLDER}`,
       );
-      cachedRedirectUrl = cachedUrl;
+      if (!cachedUrl.searchParams.has("ingestpb", "true")) {
+        cachedRedirectUrl = cachedUrl;
+      }
     }
 
     return parsedUrl;


### PR DESCRIPTION
We don't want redirect URL caching for ingest playback, if playback errors occur we want to go back to the top level playback url so that we follow the redirect process again and ensure we're still routed to the ingest node.