### PR TITLE
Flag to disable wait for ICE gathering

### DIFF
--- a/packages/core-web/package.json
+++ b/packages/core-web/package.json
@@ -13,9 +13,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -56,27 +54,13 @@
   },
   "typesVersions": {
     "*": {
-      "broadcast": [
-        "./dist/broadcast/index.d.ts"
-      ],
-      "browser": [
-        "./dist/browser/index.d.ts"
-      ],
-      "external": [
-        "./dist/external/index.d.ts"
-      ],
-      "hls": [
-        "./dist/hls/index.d.ts"
-      ],
-      "media": [
-        "./dist/media/index.d.ts"
-      ],
-      "webrtc": [
-        "./dist/webrtc/index.d.ts"
-      ],
-      "*": [
-        "./dist/index.d.ts"
-      ]
+      "broadcast": ["./dist/broadcast/index.d.ts"],
+      "browser": ["./dist/browser/index.d.ts"],
+      "external": ["./dist/external/index.d.ts"],
+      "hls": ["./dist/hls/index.d.ts"],
+      "media": ["./dist/media/index.d.ts"],
+      "webrtc": ["./dist/webrtc/index.d.ts"],
+      "*": ["./dist/index.d.ts"]
     }
   },
   "scripts": {
@@ -90,10 +74,5 @@
     "hls.js": "^1.5.14",
     "zustand": "^4.5.5"
   },
-  "keywords": [
-    "livepeer",
-    "video",
-    "streaming",
-    "livestream"
-  ]
+  "keywords": ["livepeer", "video", "streaming", "livestream"]
 }

--- a/packages/core-web/src/broadcast.ts
+++ b/packages/core-web/src/broadcast.ts
@@ -140,6 +140,13 @@ export type InitialBroadcastProps = {
    * Set to false to initialize the broadcast to not request a video track.
    */
   video: boolean | Omit<MediaTrackConstraints, "deviceId">;
+
+  /**
+   * Whether to disable ICE gathering.
+   *
+   * Set to true to disable ICE gathering. This is useful for testing purposes.
+   */
+  noIceGathering?: boolean;
 };
 
 export type BroadcastAriaText = {
@@ -190,9 +197,6 @@ export type BroadcastState = {
 
   /** The currently selected media devices. */
   mediaDeviceIds: MediaDeviceIds;
-
-  /** TODO */
-  noIceGathering: boolean;
 
   /** The initial props passed into the component. */
   __initialProps: InitialBroadcastProps;
@@ -314,8 +318,6 @@ export const createBroadcastStore = ({
                 : "Turn video off (v)",
           },
 
-          noIceGathering: false,
-
           __initialProps: {
             aspectRatio: initialProps?.aspectRatio ?? null,
             audio: initialProps?.audio ?? true,
@@ -324,6 +326,7 @@ export const createBroadcastStore = ({
             hotkeys: initialProps.hotkeys ?? true,
             ingestUrl: ingestUrl ?? null,
             video: initialProps?.video ?? true,
+            noIceGathering: initialProps?.noIceGathering ?? false,
           },
 
           __device: device,
@@ -737,13 +740,13 @@ const addEffectsToStore = (
 
   // Subscribe to request user media
   const destroyWhip = store.subscribe(
-    ({ enabled, ingestUrl, __controls, mounted, noIceGathering }) => ({
+    ({ enabled, ingestUrl, __controls, mounted, __initialProps }) => ({
       enabled,
       ingestUrl,
       requestedForceRenegotiateLastTime:
         __controls.requestedForceRenegotiateLastTime,
       mounted,
-      noIceGathering,
+      noIceGathering: __initialProps.noIceGathering,
     }),
     async ({ enabled, ingestUrl, noIceGathering }) => {
       await cleanupWhip?.();

--- a/packages/core-web/src/broadcast.ts
+++ b/packages/core-web/src/broadcast.ts
@@ -22,6 +22,7 @@ import {
 } from "./webrtc/whip";
 
 const delay = (ms: number) => {
+  console.log("delay function");
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
@@ -190,6 +191,9 @@ export type BroadcastState = {
   /** The currently selected media devices. */
   mediaDeviceIds: MediaDeviceIds;
 
+  /** TODO */
+  noIceGathering: boolean;
+
   /** The initial props passed into the component. */
   __initialProps: InitialBroadcastProps;
   /** The broadcast device information and support. */
@@ -309,6 +313,8 @@ export const createBroadcastStore = ({
                 ? "Turn video on (v)"
                 : "Turn video off (v)",
           },
+
+          noIceGathering: false,
 
           __initialProps: {
             aspectRatio: initialProps?.aspectRatio ?? null,
@@ -731,14 +737,15 @@ const addEffectsToStore = (
 
   // Subscribe to request user media
   const destroyWhip = store.subscribe(
-    ({ enabled, ingestUrl, __controls, mounted }) => ({
+    ({ enabled, ingestUrl, __controls, mounted, noIceGathering }) => ({
       enabled,
       ingestUrl,
       requestedForceRenegotiateLastTime:
         __controls.requestedForceRenegotiateLastTime,
       mounted,
+      noIceGathering,
     }),
-    async ({ enabled, ingestUrl }) => {
+    async ({ enabled, ingestUrl, noIceGathering }) => {
       await cleanupWhip?.();
 
       if (!enabled) {
@@ -779,6 +786,7 @@ const addEffectsToStore = (
           onError: onErrorComposed,
         },
         sdpTimeout: null,
+        noIceGathering,
       });
 
       cleanupWhip = () => {

--- a/packages/core-web/src/broadcast.ts
+++ b/packages/core-web/src/broadcast.ts
@@ -22,7 +22,6 @@ import {
 } from "./webrtc/whip";
 
 const delay = (ms: number) => {
-  console.log("delay function");
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 

--- a/packages/core-web/src/webrtc/shared.ts
+++ b/packages/core-web/src/webrtc/shared.ts
@@ -245,7 +245,6 @@ export async function getRedirectUrl(
   abortController: AbortController,
   timeout: number | null,
 ) {
-  // return new URL(endpoint);
   try {
     if (cachedRedirectUrl) {
       const inputUrl = new URL(endpoint);
@@ -259,8 +258,6 @@ export async function getRedirectUrl(
       () => abortController.abort(),
       timeout ?? DEFAULT_TIMEOUT,
     );
-
-    console.log(`getting redirect URL ${endpoint}`);
 
     const response = await fetch(endpoint, {
       method: "HEAD",
@@ -302,15 +299,14 @@ export async function getRedirectUrl(
 async function waitToCompleteICEGathering(peerConnection: RTCPeerConnection) {
   return new Promise<RTCSessionDescription | null>((resolve) => {
     /** Wait at most five seconds for ICE gathering. */
-    // setTimeout(() => {
-    // console.log("timed out ice gathering")
-    resolve(peerConnection.localDescription);
-    // }, 5000);
-    // peerConnection.onicegatheringstatechange = (_ev) => {
-    //   if (peerConnection.iceGatheringState === "complete") {
-    //     resolve(peerConnection.localDescription);
-    //   }
-    // };
+    setTimeout(() => {
+      resolve(peerConnection.localDescription);
+    }, 5000);
+    peerConnection.onicegatheringstatechange = (_ev) => {
+      if (peerConnection.iceGatheringState === "complete") {
+        resolve(peerConnection.localDescription);
+      }
+    };
   });
 }
 

--- a/packages/core-web/src/webrtc/whip.ts
+++ b/packages/core-web/src/webrtc/whip.ts
@@ -25,6 +25,7 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
   element,
   callbacks,
   sdpTimeout,
+  noIceGathering,
 }: {
   ingestUrl: string;
   element: TElement;
@@ -34,6 +35,7 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
     onError?: (data: Error) => void;
   };
   sdpTimeout: number | null;
+  noIceGathering?: boolean;
 }): {
   destroy: () => void;
 } => {
@@ -74,6 +76,7 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
             const ofr = await constructClientOffer(
               peerConnection,
               redirectUrlString,
+              noIceGathering,
             );
 
             await negotiateConnectionWithClientOffer(

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,5 +1,5 @@
-const core = "@livepeer/core@3.2.5";
-const react = "@livepeer/react@4.2.5";
+const core = "@livepeer/core@3.2.7";
+const react = "@livepeer/react@4.2.10";
 
 export const version = {
   core,

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,5 +1,5 @@
-const core = "@livepeer/core@3.2.7";
-const react = "@livepeer/react@4.2.10";
+const core = "@livepeer/core@3.2.5";
+const react = "@livepeer/react@4.2.5";
 
 export const version = {
   core,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@livepeer/react",
   "description": "React primitives for video apps.",
   "license": "MIT",
-  "version": "4.2.10",
+  "version": "4.2.9",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@livepeer/react",
   "description": "React primitives for video apps.",
   "license": "MIT",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "type": "module",
   "repository": {
     "type": "git",
@@ -13,9 +13,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -51,24 +49,12 @@
   },
   "typesVersions": {
     "*": {
-      "assets": [
-        "./dist/assets/index.d.ts"
-      ],
-      "broadcast": [
-        "./dist/broadcast/index.d.ts"
-      ],
-      "crypto": [
-        "./dist/crypto/index.d.ts"
-      ],
-      "external": [
-        "./dist/external/index.d.ts"
-      ],
-      "player": [
-        "./dist/player/index.d.ts"
-      ],
-      "*": [
-        "./dist/index.d.ts"
-      ]
+      "assets": ["./dist/assets/index.d.ts"],
+      "broadcast": ["./dist/broadcast/index.d.ts"],
+      "crypto": ["./dist/crypto/index.d.ts"],
+      "external": ["./dist/external/index.d.ts"],
+      "player": ["./dist/player/index.d.ts"],
+      "*": ["./dist/index.d.ts"]
     }
   },
   "scripts": {
@@ -114,11 +100,5 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
-  "keywords": [
-    "livepeer",
-    "react",
-    "video",
-    "streaming",
-    "livestream"
-  ]
+  "keywords": ["livepeer", "react", "video", "streaming", "livestream"]
 }

--- a/packages/react/src/broadcast/Broadcast.tsx
+++ b/packages/react/src/broadcast/Broadcast.tsx
@@ -55,6 +55,8 @@ interface BroadcastProps
    * The interval at which metrics are sent, in ms. Defaults to 5000.
    */
   metricsInterval?: number;
+
+  noIceGathering?: boolean;
 }
 
 const Broadcast = (
@@ -114,6 +116,7 @@ const Broadcast = (
               },
         ),
       ingestUrl,
+
       initialProps: {
         aspectRatio,
         ...rest,
@@ -146,6 +149,7 @@ const Broadcast = (
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: no deps
   useEffect(() => {
+    console.log("HELLO 3");
     const metrics = addMetricsToStore(mediaStore.current.store, {
       onPlaybackEvents,
       interval: metricsInterval,

--- a/packages/react/src/broadcast/Broadcast.tsx
+++ b/packages/react/src/broadcast/Broadcast.tsx
@@ -116,7 +116,6 @@ const Broadcast = (
               },
         ),
       ingestUrl,
-
       initialProps: {
         aspectRatio,
         ...rest,
@@ -149,7 +148,6 @@ const Broadcast = (
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: no deps
   useEffect(() => {
-    console.log("HELLO 3");
     const metrics = addMetricsToStore(mediaStore.current.store, {
       onPlaybackEvents,
       interval: metricsInterval,


### PR DESCRIPTION
We found in the case of the pipelines app there was no need to wait for this ICE gathering step so being able to disable this saves us 5s of startup time.