### PR TITLE
broadcast: add support for custom ICE servers

### DIFF
--- a/packages/core-web/src/broadcast.ts
+++ b/packages/core-web/src/broadcast.ts
@@ -351,6 +351,8 @@ export const createBroadcastStore = ({
             ingestUrl: ingestUrl ?? null,
             video: initialProps?.video ?? true,
             noIceGathering: initialProps?.noIceGathering ?? false,
+            stunServers: initialProps?.stunServers,
+            turnServers: initialProps?.turnServers,
             mirrored: initialProps?.mirrored ?? false,
           },
 

--- a/packages/core-web/src/broadcast.ts
+++ b/packages/core-web/src/broadcast.ts
@@ -142,7 +142,7 @@ export type InitialBroadcastProps = {
   video: boolean | Omit<MediaTrackConstraints, "deviceId">;
 
   /**
-   * @deprecated in favor of `stunServers` and `turnServers`
+   * @deprecated in favor of `iceServers`
    *
    * Whether to disable ICE gathering.
    *
@@ -151,18 +151,11 @@ export type InitialBroadcastProps = {
   noIceGathering?: boolean;
 
   /**
-   * The STUN servers to use.
+   * The ICE servers to use.
    *
-   * If not provided, the default STUN servers will be used.
+   * If not provided, the default ICE servers will be used.
    */
-  stunServers?: RTCIceServer | RTCIceServer[];
-
-  /**
-   * The TURN servers to use.
-   *
-   * If not provided, the default TURN servers will be used.
-   */
-  turnServers?: RTCIceServer | RTCIceServer[];
+  iceServers?: RTCIceServer | RTCIceServer[];
 
   /**
    * Whether the video stream should be mirrored (horizontally flipped).
@@ -351,8 +344,7 @@ export const createBroadcastStore = ({
             ingestUrl: ingestUrl ?? null,
             video: initialProps?.video ?? true,
             noIceGathering: initialProps?.noIceGathering ?? false,
-            stunServers: initialProps?.stunServers,
-            turnServers: initialProps?.turnServers,
+            iceServers: initialProps?.iceServers,
             mirrored: initialProps?.mirrored ?? false,
           },
 
@@ -778,16 +770,9 @@ const addEffectsToStore = (
         __controls.requestedForceRenegotiateLastTime,
       mounted,
       noIceGathering: __initialProps.noIceGathering,
-      stunServers: __initialProps.stunServers,
-      turnServers: __initialProps.turnServers,
+      iceServers: __initialProps.iceServers,
     }),
-    async ({
-      enabled,
-      ingestUrl,
-      noIceGathering,
-      stunServers,
-      turnServers,
-    }) => {
+    async ({ enabled, ingestUrl, noIceGathering, iceServers }) => {
       await cleanupWhip?.();
 
       if (!enabled) {
@@ -829,8 +814,7 @@ const addEffectsToStore = (
         },
         sdpTimeout: null,
         noIceGathering,
-        stunServers,
-        turnServers,
+        iceServers,
       });
 
       cleanupWhip = () => {

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -470,6 +470,8 @@ const addEffectsToStore = (
             accessKey: store.getState().__initialProps.accessKey,
           },
           sdpTimeout: timeout,
+          stunServers: store.getState().__initialProps.stunServers,
+          turnServers: store.getState().__initialProps.turnServers,
         });
 
         const id = setTimeout(() => {

--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -470,8 +470,7 @@ const addEffectsToStore = (
             accessKey: store.getState().__initialProps.accessKey,
           },
           sdpTimeout: timeout,
-          stunServers: store.getState().__initialProps.stunServers,
-          turnServers: store.getState().__initialProps.turnServers,
+          iceServers: store.getState().__initialProps.iceServers,
         });
 
         const id = setTimeout(() => {

--- a/packages/core-web/src/webrtc/shared.ts
+++ b/packages/core-web/src/webrtc/shared.ts
@@ -26,21 +26,17 @@ export function createPeerConnection(
   const RTCPeerConnectionConstructor = getRTCPeerConnectionConstructor();
 
   if (RTCPeerConnectionConstructor) {
-    // strip non-standard port number if present
-    const hostNoPort = host?.split(":")[0];
-
-    const iceServers = host
-      ? [
-          {
-            urls: `stun:${hostNoPort}`,
-          },
-          {
-            urls: `turn:${hostNoPort}`,
-            username: "livepeer",
-            credential: "livepeer",
-          },
-        ]
-      : [];
+    const iceServers = [
+      {
+        urls: [
+          "stun:stun.l.google.com:19302",
+          "stun:stun1.l.google.com:19302",
+          "stun:stun2.l.google.com:19302",
+          "stun:stun3.l.google.com:19302",
+          "stun:stun4.l.google.com:19302",
+        ],
+      },
+    ];
 
     return new RTCPeerConnectionConstructor({ iceServers });
   }

--- a/packages/core-web/src/webrtc/shared.ts
+++ b/packages/core-web/src/webrtc/shared.ts
@@ -25,8 +25,7 @@ export const getRTCPeerConnectionConstructor = () => {
  */
 export function createPeerConnection(
   host: string | null,
-  stunServers?: RTCIceServer | RTCIceServer[],
-  turnServers?: RTCIceServer | RTCIceServer[],
+  iceServers?: RTCIceServer | RTCIceServer[],
 ): RTCPeerConnection | null {
   const RTCPeerConnectionConstructor = getRTCPeerConnectionConstructor();
 
@@ -36,15 +35,11 @@ export function createPeerConnection(
 
   // Defaults to Mist behavior
   const hostNoPort = host?.split(":")[0];
-  const defaultStunServer = host
+  const defaultIceServers = host
     ? [
         {
           urls: `stun:${hostNoPort}`,
         },
-      ]
-    : [];
-  const defaultTurnServer = host
-    ? [
         {
           urls: `turn:${hostNoPort}`,
           username: "livepeer",
@@ -53,20 +48,13 @@ export function createPeerConnection(
       ]
     : [];
 
-  const iceServers = [
-    ...(stunServers
-      ? Array.isArray(stunServers)
-        ? stunServers
-        : [stunServers]
-      : defaultStunServer),
-    ...(turnServers
-      ? Array.isArray(turnServers)
-        ? turnServers
-        : [turnServers]
-      : defaultTurnServer),
-  ];
-
-  return new RTCPeerConnectionConstructor({ iceServers });
+  return new RTCPeerConnectionConstructor({
+    iceServers: iceServers
+      ? Array.isArray(iceServers)
+        ? iceServers
+        : [iceServers]
+      : defaultIceServers,
+  });
 }
 
 const DEFAULT_TIMEOUT = 10000;

--- a/packages/core-web/src/webrtc/whep.ts
+++ b/packages/core-web/src/webrtc/whep.ts
@@ -21,6 +21,8 @@ export const createNewWHEP = <TElement extends HTMLMediaElement>({
   callbacks,
   accessControl,
   sdpTimeout,
+  stunServers,
+  turnServers,
 }: {
   source: string;
   element: TElement;
@@ -32,6 +34,8 @@ export const createNewWHEP = <TElement extends HTMLMediaElement>({
   };
   accessControl: AccessControlParams;
   sdpTimeout: number | null;
+  stunServers?: RTCIceServer | RTCIceServer[];
+  turnServers?: RTCIceServer | RTCIceServer[];
 }): {
   destroy: () => void;
 } => {
@@ -76,7 +80,11 @@ export const createNewWHEP = <TElement extends HTMLMediaElement>({
        * allowing the client to discover its own IP address.
        * https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols#ice
        */
-      peerConnection = createPeerConnection(redirectUrl.host);
+      peerConnection = createPeerConnection(
+        redirectUrl.host,
+        stunServers,
+        turnServers,
+      );
 
       if (peerConnection) {
         /** https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver */

--- a/packages/core-web/src/webrtc/whep.ts
+++ b/packages/core-web/src/webrtc/whep.ts
@@ -21,8 +21,7 @@ export const createNewWHEP = <TElement extends HTMLMediaElement>({
   callbacks,
   accessControl,
   sdpTimeout,
-  stunServers,
-  turnServers,
+  iceServers,
 }: {
   source: string;
   element: TElement;
@@ -34,8 +33,7 @@ export const createNewWHEP = <TElement extends HTMLMediaElement>({
   };
   accessControl: AccessControlParams;
   sdpTimeout: number | null;
-  stunServers?: RTCIceServer | RTCIceServer[];
-  turnServers?: RTCIceServer | RTCIceServer[];
+  iceServers?: RTCIceServer | RTCIceServer[];
 }): {
   destroy: () => void;
 } => {
@@ -80,11 +78,7 @@ export const createNewWHEP = <TElement extends HTMLMediaElement>({
        * allowing the client to discover its own IP address.
        * https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols#ice
        */
-      peerConnection = createPeerConnection(
-        redirectUrl.host,
-        stunServers,
-        turnServers,
-      );
+      peerConnection = createPeerConnection(redirectUrl.host, iceServers);
 
       if (peerConnection) {
         /** https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver */

--- a/packages/core-web/src/webrtc/whip.ts
+++ b/packages/core-web/src/webrtc/whip.ts
@@ -28,8 +28,7 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
   callbacks,
   sdpTimeout,
   noIceGathering,
-  stunServers,
-  turnServers,
+  iceServers,
 }: {
   ingestUrl: string;
   element: TElement;
@@ -40,8 +39,7 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
   };
   sdpTimeout: number | null;
   noIceGathering?: boolean;
-  stunServers?: RTCIceServer | RTCIceServer[];
-  turnServers?: RTCIceServer | RTCIceServer[];
+  iceServers?: RTCIceServer | RTCIceServer[];
 }): {
   destroy: () => void;
 } => {
@@ -74,11 +72,7 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
        * allowing the client to discover its own IP address.
        * https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols#ice
        */
-      peerConnection = createPeerConnection(
-        redirectUrl.host,
-        stunServers,
-        turnServers,
-      );
+      peerConnection = createPeerConnection(redirectUrl.host, iceServers);
 
       if (peerConnection) {
         peerConnection.addEventListener("negotiationneeded", async (_ev) => {

--- a/packages/core-web/src/webrtc/whip.ts
+++ b/packages/core-web/src/webrtc/whip.ts
@@ -28,6 +28,8 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
   callbacks,
   sdpTimeout,
   noIceGathering,
+  stunServers,
+  turnServers,
 }: {
   ingestUrl: string;
   element: TElement;
@@ -38,6 +40,8 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
   };
   sdpTimeout: number | null;
   noIceGathering?: boolean;
+  stunServers?: RTCIceServer | RTCIceServer[];
+  turnServers?: RTCIceServer | RTCIceServer[];
 }): {
   destroy: () => void;
 } => {
@@ -70,7 +74,11 @@ export const createNewWHIP = <TElement extends HTMLMediaElement>({
        * allowing the client to discover its own IP address.
        * https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols#ice
        */
-      peerConnection = createPeerConnection(redirectUrl.host);
+      peerConnection = createPeerConnection(
+        redirectUrl.host,
+        stunServers,
+        turnServers,
+      );
 
       if (peerConnection) {
         peerConnection.addEventListener("negotiationneeded", async (_ev) => {

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -156,6 +156,20 @@ export type InitialProps = {
   viewerId: string | null;
 
   ingestPlayback: boolean;
+
+  /**
+   * The STUN servers to use.
+   *
+   * If not provided, the default STUN servers will be used.
+   */
+  stunServers?: RTCIceServer | RTCIceServer[];
+
+  /**
+   * The TURN servers to use.
+   *
+   * If not provided, the default TURN servers will be used.
+   */
+  turnServers?: RTCIceServer | RTCIceServer[];
 };
 
 export type DeviceInformation = {
@@ -662,6 +676,8 @@ export const createControllerStore = ({
             viewerId: initialProps.viewerId ?? null,
             volume: initialVolume ?? null,
             ingestPlayback: initialProps.ingestPlayback ?? false,
+            stunServers: initialProps.stunServers,
+            turnServers: initialProps.turnServers,
           },
 
           __device: device,

--- a/packages/core/src/media/controller.ts
+++ b/packages/core/src/media/controller.ts
@@ -158,18 +158,11 @@ export type InitialProps = {
   ingestPlayback: boolean;
 
   /**
-   * The STUN servers to use.
+   * The ICE servers to use.
    *
-   * If not provided, the default STUN servers will be used.
+   * If not provided, the default ICE servers will be used.
    */
-  stunServers?: RTCIceServer | RTCIceServer[];
-
-  /**
-   * The TURN servers to use.
-   *
-   * If not provided, the default TURN servers will be used.
-   */
-  turnServers?: RTCIceServer | RTCIceServer[];
+  iceServers?: RTCIceServer | RTCIceServer[];
 };
 
 export type DeviceInformation = {
@@ -676,8 +669,7 @@ export const createControllerStore = ({
             viewerId: initialProps.viewerId ?? null,
             volume: initialVolume ?? null,
             ingestPlayback: initialProps.ingestPlayback ?? false,
-            stunServers: initialProps.stunServers,
-            turnServers: initialProps.turnServers,
+            iceServers: initialProps.iceServers,
           },
 
           __device: device,

--- a/packages/react/src/broadcast/Broadcast.tsx
+++ b/packages/react/src/broadcast/Broadcast.tsx
@@ -57,7 +57,7 @@ interface BroadcastProps
   metricsInterval?: number;
 
   /**
-   * @deprecated in favor of `stunServers` and `turnServers`
+   * @deprecated in favor of `iceServers`
    *
    * Whether to disable ICE gathering.
    *
@@ -66,18 +66,11 @@ interface BroadcastProps
   noIceGathering?: boolean;
 
   /**
-   * The STUN servers to use.
+   * The ICE servers to use.
    *
-   * If not provided, the default STUN servers will be used.
+   * If not provided, the default ICE servers will be used.
    */
-  stunServers?: RTCIceServer | RTCIceServer[];
-
-  /**
-   * The TURN servers to use.
-   *
-   * If not provided, the default TURN servers will be used.
-   */
-  turnServers?: RTCIceServer | RTCIceServer[];
+  iceServers?: RTCIceServer | RTCIceServer[];
 }
 
 const Broadcast = (

--- a/packages/react/src/broadcast/Broadcast.tsx
+++ b/packages/react/src/broadcast/Broadcast.tsx
@@ -56,7 +56,28 @@ interface BroadcastProps
    */
   metricsInterval?: number;
 
+  /**
+   * @deprecated in favor of `stunServers` and `turnServers`
+   *
+   * Whether to disable ICE gathering.
+   *
+   * Set to true to disable ICE gathering. This is useful for testing purposes.
+   */
   noIceGathering?: boolean;
+
+  /**
+   * The STUN servers to use.
+   *
+   * If not provided, the default STUN servers will be used.
+   */
+  stunServers?: RTCIceServer | RTCIceServer[];
+
+  /**
+   * The TURN servers to use.
+   *
+   * If not provided, the default TURN servers will be used.
+   */
+  turnServers?: RTCIceServer | RTCIceServer[];
 }
 
 const Broadcast = (

--- a/packages/react/src/player/Player.tsx
+++ b/packages/react/src/player/Player.tsx
@@ -53,6 +53,20 @@ interface PlayerProps
    * The interval at which metrics are sent, in ms. Defaults to 5000.
    */
   metricsInterval?: number;
+
+  /**
+   * The STUN servers to use.
+   *
+   * If not provided, the default STUN servers will be used.
+   */
+  stunServers?: RTCIceServer | RTCIceServer[];
+
+  /**
+   * The TURN servers to use.
+   *
+   * If not provided, the default TURN servers will be used.
+   */
+  turnServers?: RTCIceServer | RTCIceServer[];
 }
 
 const Player = React.memo((props: MediaScopedProps<PlayerProps>) => {

--- a/packages/react/src/player/Player.tsx
+++ b/packages/react/src/player/Player.tsx
@@ -55,18 +55,11 @@ interface PlayerProps
   metricsInterval?: number;
 
   /**
-   * The STUN servers to use.
+   * The ICE servers to use.
    *
-   * If not provided, the default STUN servers will be used.
+   * If not provided, the default ICE servers will be used.
    */
-  stunServers?: RTCIceServer | RTCIceServer[];
-
-  /**
-   * The TURN servers to use.
-   *
-   * If not provided, the default TURN servers will be used.
-   */
-  turnServers?: RTCIceServer | RTCIceServer[];
+  iceServers?: RTCIceServer | RTCIceServer[];
 }
 
 const Player = React.memo((props: MediaScopedProps<PlayerProps>) => {


### PR DESCRIPTION
## Description

- Updated `createPeerConnection` to support custom ICE servers.
- Added `iceServers` prop to `Player` and `Broadcast` component.
- Deprecated `noIceGathering` flag.

## Additional Information

- [x] I read the [contributing docs](/livepeer/ui-kit/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
