### PR TITLE
fix: set canvas dimensions dynamically

### DIFF
--- a/packages/core-web/src/webrtc/whip.ts
+++ b/packages/core-web/src/webrtc/whip.ts
@@ -283,8 +283,6 @@ export const createMirroredVideoTrack = (
   }
 
   try {
-    const settings = originalTrack.getSettings();
-
     const canvas = document.createElement("canvas");
 
     const ctx = canvas.getContext("2d");

--- a/packages/core-web/src/webrtc/whip.ts
+++ b/packages/core-web/src/webrtc/whip.ts
@@ -296,6 +296,8 @@ export const createMirroredVideoTrack = (
     video.autoplay = true;
     video.muted = true;
 
+    let animationFrameId: number;
+
     const drawFrame = () => {
       if (video.readyState >= 2) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -306,7 +308,7 @@ export const createMirroredVideoTrack = (
         ctx.restore();
       }
 
-      requestAnimationFrame(drawFrame);
+      animationFrameId = requestAnimationFrame(drawFrame);
     };
 
     video.onloadedmetadata = () => {
@@ -323,10 +325,10 @@ export const createMirroredVideoTrack = (
     };
 
     const mirroredStream = canvas.captureStream(STANDARD_FPS);
-
     const mirroredTrack = mirroredStream.getVideoTracks()[0];
 
     originalTrack.addEventListener("ended", () => {
+      cancelAnimationFrame(animationFrameId);
       mirroredTrack.stop();
       video.pause();
       video.srcObject = null;

--- a/packages/core-web/src/webrtc/whip.ts
+++ b/packages/core-web/src/webrtc/whip.ts
@@ -284,12 +284,8 @@ export const createMirroredVideoTrack = (
 
   try {
     const settings = originalTrack.getSettings();
-    const width = settings.width || 640;
-    const height = settings.height || 480;
 
     const canvas = document.createElement("canvas");
-    canvas.width = width;
-    canvas.height = height;
 
     const ctx = canvas.getContext("2d");
     if (!ctx) {
@@ -303,6 +299,9 @@ export const createMirroredVideoTrack = (
     video.muted = true;
 
     video.onloadedmetadata = () => {
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+
       video
         .play()
         .catch((e) =>
@@ -312,11 +311,11 @@ export const createMirroredVideoTrack = (
 
     const drawFrame = () => {
       if (video.readyState >= 2) {
-        ctx.clearRect(0, 0, width, height);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
 
         ctx.save();
         ctx.scale(-1, 1);
-        ctx.drawImage(video, -width, 0, width, height);
+        ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
         ctx.restore();
       }
 

--- a/packages/core-web/src/webrtc/whip.ts
+++ b/packages/core-web/src/webrtc/whip.ts
@@ -296,17 +296,6 @@ export const createMirroredVideoTrack = (
     video.autoplay = true;
     video.muted = true;
 
-    video.onloadedmetadata = () => {
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-
-      video
-        .play()
-        .catch((e) =>
-          warn(`Failed to play video in mirroring process: ${e.message}`),
-        );
-    };
-
     const drawFrame = () => {
       if (video.readyState >= 2) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -320,7 +309,18 @@ export const createMirroredVideoTrack = (
       requestAnimationFrame(drawFrame);
     };
 
-    drawFrame();
+    video.onloadedmetadata = () => {
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+
+      video
+        .play()
+        .catch((e) =>
+          warn(`Failed to play video in mirroring process: ${e.message}`),
+        );
+
+      drawFrame();
+    };
 
     const mirroredStream = canvas.captureStream(STANDARD_FPS);
 


### PR DESCRIPTION
## Description

- Use the intrinsic dimensions of the video for mirroring

## Additional Information

- [ ] I read the [contributing docs](/livepeer/ui-kit/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
