### PR TITLE
Re-render controls when lastError changes

### DIFF
--- a/packages/core-web/src/media/controls/controller.ts
+++ b/packages/core-web/src/media/controls/controller.ts
@@ -368,6 +368,7 @@ const addEffectsToStore = (
       backoffMax: __initialProps.backoffMax,
       calculateDelay: __initialProps.calculateDelay,
       errorCount,
+      lastError: __controls.lastError,
       hlsConfig: __controls.hlsConfig,
       mounted,
       progress,
@@ -382,6 +383,7 @@ const addEffectsToStore = (
       backoffMax,
       calculateDelay,
       errorCount,
+      lastError,
       hlsConfig,
       mounted,
       progress,
@@ -590,12 +592,13 @@ const addEffectsToStore = (
       equalityFn: (a, b) => {
         const errorCountChanged =
           a.errorCount !== b.errorCount && b.errorCount !== 0;
+        const lastErrorChanged = a.lastError !== b.lastError;
 
         const sourceChanged = a.source?.src !== b.source?.src;
         const mountedChanged = a.mounted !== b.mounted;
 
         const shouldReRender =
-          errorCountChanged || sourceChanged || mountedChanged;
+          errorCountChanged || lastErrorChanged || sourceChanged || mountedChanged;
 
         return !shouldReRender;
       },


### PR DESCRIPTION
## Description

This PR fixes the issue that the player may not re-render when an error happens. Here's a scenario we encounter in Daydream App:
1. Effect Store is created with the default params
2. Error happens, the `errorCount` is increased to the value of `2`, the player is re-rendered as expected
3. Parent component is re-rendered, which causes the store to re-create, `errorCount` is again `1`
4. Error happens, the `errorCount` is increased to the value of `2`, the player is **not** re-rendered, because `errorCount` has not changed (it is again `2`); visually, a users sees a grey screen instead of the stream playback.

This PR fixes this issue, because by having `lastError` timestamp in the equality function, we will always re-render the player if any error happens.

Side note re point 3: I'm not 100% sure why we re-render the parent component and why it causes the store to be recreated. I see we're re-rendering all the components every 1s, and that causes (sometimes) the store recreation. @junhyr @gioelecerati you may have some ideas here.

## Additional Information

- [x] I read the [contributing docs](/livepeer/ui-kit/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
